### PR TITLE
Create Vue app immediately to avoid showing JavaScript notice shortly

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -32,12 +32,10 @@ const backToTop = function () {
 };
 
 window.addEventListener('load', () => {
+  const app = createApp(App);
+  app.use(router).mount('#app');
   axios('/app-config').then(response => {
-    const config = response.data;
-    const app = createApp(App);
-    app.config.globalProperties.appConfig = config;
-    app.use(router).mount('#app');
-
-    backToTop();
+    app.config.globalProperties.appConfig = response.data;
   });
+  backToTop();
 });


### PR DESCRIPTION
Otherwise "This application requires JavaScript!" is shortly visible until
the AJAX request has finished (which looks rather ugly).

---

Note that I currently don't know what speaks against it. However, maybe
this should be tested in a more realistic setup first.