### PR TITLE
Let's have dependabot create 3 PRs per week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
The previous (default) limit of 5 PRs a month were not nearly enough to keep our dependencies uptodate. So let's go with 3 per week, which would be more than double to what we had before