### PR TITLE
CI: Have dependabot create daily PRs but don't merge them before 2 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 4

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,6 +32,7 @@ pull_request_rules:
         # one from the base checks
         - base=main
         - author=dependabot[bot]
+        - "label=deps-waited"
     actions: *merge
   - name: ask to resolve conflict
     conditions:
@@ -39,3 +40,12 @@ pull_request_rules:
     actions:
       comment:
         message: This pull request is now in conflicts. Could you fix it? 🙏
+  - name: Wait for 2 days before validating merge
+    actions:
+      label:
+        add:
+          - deps-waited
+    conditions:
+      - and:
+          - updated-at<2 days ago
+          - author=dependabot[bot]


### PR DESCRIPTION
To avoid taking broken dependencies right away - but give humans a chance to intervene