### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ For a local PostgreSQL instance with a username and password one could call:
 ```
 TEST_ONLINE=postgresql://postgres:postgres@localhost:5432/postgres prove -l t/*.t t/*.t.js
 ```
-### Local Development
-
-An quick way to build and run the dashboard and its dependencies can be with docker.
-More info here https://gitlab.suse.de/qsf-u/dev-dashboard
+### Further notes
+A containerized environment could be used to build and run the dashboard and its dependencies.
+For a concrete example, checkout the (so far) internal documentation under
+https://gitlab.suse.de/qsf-u/dev-dashboard.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ For a local PostgreSQL instance with a username and password one could call:
 ```
 TEST_ONLINE=postgresql://postgres:postgres@localhost:5432/postgres prove -l t/*.t t/*.t.js
 ```
+### Local Development
+
+An quick way to build and run the dashboard and its dependencies can be with docker.
+More info here https://gitlab.suse.de/qsf-u/dev-dashboard
 
 ## License
 


### PR DESCRIPTION
Add internal link about local development with docker.

If the liked repo is considered useful enough, we could think about moving the docker files into this project and keep internal only the tutorial on how to dump the database.