### PR TITLE
Introduce a filter for job groups in blocked page

### DIFF
--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -7,7 +7,7 @@
       <div v-if="Object.keys(incidentResults).length + Object.keys(updateResults).length === 0">No data yet</div>
       <ul v-else class="summary-list">
         <BlockedIncidentIncResult
-          v-for="(result, group_id) in incidentResults"
+          v-for="(result, group_id) in incidentResultsGrouped"
           :key="group_id"
           :group-id="group_id"
           :result="result"
@@ -40,7 +40,8 @@ export default {
     incident: {type: Object, required: true},
     incidentResults: {type: Object, required: true},
     updateResults: {type: Object, required: true},
-    groupFlavors: {type: Boolean, required: true}
+    groupFlavors: {type: Boolean, required: true},
+    groupNames: {type: String, required: true}
   },
   computed: {
     updateResultsGrouped() {
@@ -51,16 +52,30 @@ export default {
         const {version} = value.linkinfo;
         const {groupid} = value.linkinfo;
         const newkey = `${groupid}:${version}`;
-        if (!(newkey in results)) {
-          results[newkey] = {name: value.name, passed: 0, failed: 0, stopped: 0, waiting: 0};
-          results[newkey].linkinfo = value.linkinfo;
-          results[newkey].linkinfo.flavor = [];
+        if (this.groupNames.toLowerCase().split(',').includes(value.name.toLowerCase()) || this.groupNames == '') {
+          if (!(newkey in results)) {
+            results[newkey] = {name: value.name, passed: 0, failed: 0, stopped: 0, waiting: 0};
+            results[newkey].linkinfo = value.linkinfo;
+            results[newkey].linkinfo.flavor = [];
+          }
+          results[newkey].linkinfo.flavor.push(flavor);
+          results[newkey].passed += value.passed || 0;
+          results[newkey].stopped += value.stopped || 0;
+          results[newkey].waiting += value.waiting || 0;
+          results[newkey].failed += value.failed || 0;
         }
-        results[newkey].linkinfo.flavor.push(flavor);
-        results[newkey].passed += value.passed || 0;
-        results[newkey].stopped += value.stopped || 0;
-        results[newkey].waiting += value.waiting || 0;
-        results[newkey].failed += value.failed || 0;
+      }
+      return results;
+    },
+    incidentResultsGrouped() {
+      if (this.groupNames == '') {
+        return this.incidentResults;
+      }
+      const results = [];
+      for (const value of Object.values(this.incidentResults)) {
+        if (this.groupNames.toLowerCase().split(',').includes(value.name.toLowerCase())) {
+          results.push(value);
+        }
       }
       return results;
     }

--- a/assets/vue/components/PageBlocked.vue
+++ b/assets/vue/components/PageBlocked.vue
@@ -11,6 +11,13 @@
           id="inlineSearch"
           placeholder="Search for Incident/Package"
         />
+        <input
+          v-model="groupNames"
+          type="text"
+          class="form-control"
+          id="inlineSearch"
+          placeholder="Search for Group Names"
+        />
       </div>
       <div class="col-auto my-1">
         <div class="form-check">
@@ -34,6 +41,7 @@
           :incident-results="incident.incident_results"
           :update-results="incident.update_results"
           :group-flavors="groupFlavors"
+          :group-names="groupNames"
         />
       </tbody>
     </table>
@@ -54,21 +62,40 @@ export default {
       incidents: null,
       groupFlavors: true,
       matchText: '',
+      groupNames: '',
       refreshUrl: '/app/api/blocked'
     };
   },
   computed: {
     matchedIncidents() {
+      var results = [];
       if (this.matchText) {
-        return this.incidents.filter(incident => {
+        results = this.incidents.filter(incident => {
           if (String(incident.incident.number).includes(this.matchText)) return true;
           for (const pack of incident.incident.packages) {
             if (pack.includes(this.matchText)) return true;
           }
           return false;
         });
+      } else {
+        results = this.incidents;
       }
-      return this.incidents;
+      if (this.groupNames) {
+        return results.filter(incident => {
+          for (let key in incident.update_results) {
+            for (let groupName of this.groupNames.split(',')) {
+              if (groupName.toLowerCase() == incident.update_results[key].name.toLowerCase()) return true;
+            }
+          }
+          for (let key in incident.incident_results) {
+            for (let groupName of this.groupNames.split(',')) {
+              if (groupName.toLowerCase() == incident.incident_results[key].name.toLowerCase()) return true;
+            }
+          }
+          return false;
+        });
+      }
+      return results;
     },
     smelt() {
       return this.appConfig.smeltUrl;


### PR DESCRIPTION
Please see my message on slack eng-testing with the invitation for a quick look at the change this afternoon if you'd like!

Context: 
- Allows squads to see only job groups they are responsible for by adding one more textbox for job groups.
- Multiple job groups can be specified, separated by `,`
- poo: https://progress.opensuse.org/issues/121249

Next steps: 
- Would like to allow such filtering on url. This way squad can bookmark the link instead of typing every time in the search box
- Would like to collect data based on squads test results. Either by querying the blocked json api and do filtering again on client side or enhancing the blocked api (or add one more) to return filtered results. This is independent from the frontend filters.

Actual changes:
- PageBlocked.vue: after filtering for a partial incident name/number, also filter for exact group name (case insensitive).
Exact group name because otherwise "Maintenance" or "SLE"  would grep for everything. 
Also allow multiple job groups, separated by `,`

- BlockedIncident.vue: Now the list of incident shown is filtered (left column), but also the list of job groups "boxes" on the right column shall be filtered, for both incidents and aggregates results.

