### PR TITLE
Introduce a filter for job groups in blocked page

### DIFF
--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -7,7 +7,7 @@
       <div v-if="Object.keys(incidentResults).length + Object.keys(updateResults).length === 0">No data yet</div>
       <ul v-else class="summary-list">
         <BlockedIncidentIncResult
-          v-for="(result, group_id) in incidentResults"
+          v-for="(result, group_id) in incidentResultsGrouped"
           :key="group_id"
           :group-id="group_id"
           :result="result"
@@ -40,7 +40,8 @@ export default {
     incident: {type: Object, required: true},
     incidentResults: {type: Object, required: true},
     updateResults: {type: Object, required: true},
-    groupFlavors: {type: Boolean, required: true}
+    groupFlavors: {type: Boolean, required: true},
+    groupNames: {type: String, required: true}
   },
   computed: {
     updateResultsGrouped() {
@@ -51,16 +52,30 @@ export default {
         const {version} = value.linkinfo;
         const {groupid} = value.linkinfo;
         const newkey = `${groupid}:${version}`;
-        if (!(newkey in results)) {
-          results[newkey] = {name: value.name, passed: 0, failed: 0, stopped: 0, waiting: 0};
-          results[newkey].linkinfo = value.linkinfo;
-          results[newkey].linkinfo.flavor = [];
+        if (this.groupNames.toLowerCase().split(',').includes(value.name.toLowerCase()) || this.groupNames == '') {
+          if (!(newkey in results)) {
+            results[newkey] = {name: value.name, passed: 0, failed: 0, stopped: 0, waiting: 0};
+            results[newkey].linkinfo = value.linkinfo;
+            results[newkey].linkinfo.flavor = [];
+          }
+          results[newkey].linkinfo.flavor.push(flavor);
+          results[newkey].passed += value.passed || 0;
+          results[newkey].stopped += value.stopped || 0;
+          results[newkey].waiting += value.waiting || 0;
+          results[newkey].failed += value.failed || 0;
         }
-        results[newkey].linkinfo.flavor.push(flavor);
-        results[newkey].passed += value.passed || 0;
-        results[newkey].stopped += value.stopped || 0;
-        results[newkey].waiting += value.waiting || 0;
-        results[newkey].failed += value.failed || 0;
+      }
+      return results;
+    },
+    incidentResultsGrouped() {
+      if (this.groupNames == '') {
+        return this.incidentResults;
+      }
+      const results = [];
+      for (const value of Object.values(this.incidentResults)) {
+        if (this.groupNames.toLowerCase().split(',').includes(value.name.toLowerCase())) {
+          results.push(value);
+        }
       }
       return results;
     }

--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -47,16 +47,22 @@ export default {
     updateResultsGrouped() {
       if (!this.groupFlavors) return this.updateResults;
       const results = {};
+      const groupNamesList = this.groupNames.toLowerCase().split(',');
       for (const value of Object.values(this.updateResults)) {
         const {flavor} = value.linkinfo;
         const {version} = value.linkinfo;
         const {groupid} = value.linkinfo;
         const newkey = `${groupid}:${version}`;
-        if (this.groupNames.toLowerCase().split(',').includes(value.name.toLowerCase()) || this.groupNames == '') {
+        if (groupNamesList.includes(value.name.toLowerCase()) || this.groupNames === '') {
           if (!(newkey in results)) {
-            results[newkey] = {name: value.name, passed: 0, failed: 0, stopped: 0, waiting: 0};
-            results[newkey].linkinfo = value.linkinfo;
-            results[newkey].linkinfo.flavor = [];
+            results[newkey] = {
+              name: value.name,
+              passed: 0,
+              failed: 0,
+              stopped: 0,
+              waiting: 0,
+              linkinfo: {...value.linkinfo, flavor: []}
+            };
           }
           results[newkey].linkinfo.flavor.push(flavor);
           results[newkey].passed += value.passed || 0;
@@ -68,12 +74,13 @@ export default {
       return results;
     },
     incidentResultsGrouped() {
-      if (this.groupNames == '') {
+      if (this.groupNames === '') {
         return this.incidentResults;
       }
       const results = [];
+      const groupNamesList = this.groupNames.toLowerCase().split(',');
       for (const value of Object.values(this.incidentResults)) {
-        if (this.groupNames.toLowerCase().split(',').includes(value.name.toLowerCase())) {
+        if (groupNamesList.includes(value.name.toLowerCase())) {
           results.push(value);
         }
       }

--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -54,21 +54,19 @@ export default {
         const {groupid} = value.linkinfo;
         const newkey = `${groupid}:${version}`;
         if (groupNamesList.includes(value.name.toLowerCase()) || this.groupNames === '') {
-          if (!(newkey in results)) {
-            results[newkey] = {
-              name: value.name,
-              passed: 0,
-              failed: 0,
-              stopped: 0,
-              waiting: 0,
-              linkinfo: {...value.linkinfo, flavor: []}
-            };
-          }
-          results[newkey].linkinfo.flavor.push(flavor);
-          results[newkey].passed += value.passed || 0;
-          results[newkey].stopped += value.stopped || 0;
-          results[newkey].waiting += value.waiting || 0;
-          results[newkey].failed += value.failed || 0;
+          const res = (results[newkey] ||= {
+            name: value.name,
+            passed: 0,
+            failed: 0,
+            stopped: 0,
+            waiting: 0,
+            linkinfo: {...value.linkinfo, flavor: []}
+          });
+          res.linkinfo.flavor.push(flavor);
+          res.passed += value.passed || 0;
+          res.stopped += value.stopped || 0;
+          res.waiting += value.waiting || 0;
+          res.failed += value.failed || 0;
         }
       }
       return results;

--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -72,15 +72,11 @@ export default {
       return results;
     },
     incidentResultsGrouped() {
-      if (this.groupNames === '') {
-        return this.incidentResults;
-      }
+      if (this.groupNames === '') return this.incidentResults;
       const results = [];
       const groupNamesList = this.groupNames.toLowerCase().split(',');
       for (const value of Object.values(this.incidentResults)) {
-        if (groupNamesList.includes(value.name.toLowerCase())) {
-          results.push(value);
-        }
+        if (groupNamesList.includes(value.name.toLowerCase())) results.push(value);
       }
       return results;
     }

--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -54,7 +54,7 @@ export default {
         const {groupid} = value.linkinfo;
         const newkey = `${groupid}:${version}`;
         if (groupNamesList.includes(value.name.toLowerCase()) || this.groupNames === '') {
-          const res = (results[newkey] ||= {
+          const res = (results[newkey] = {
             name: value.name,
             passed: 0,
             failed: 0,

--- a/assets/vue/components/PageBlocked.vue
+++ b/assets/vue/components/PageBlocked.vue
@@ -2,23 +2,6 @@
   <div v-if="incidents === null"><i class="fas fa-sync fa-spin"></i> Loading incidents...</div>
   <div v-else-if="incidents.length > 0">
     <div class="row align-items-center">
-      <div class="col-sm-3 my-1">
-        <label class="sr-only" for="inlineFormInputName">Name</label>
-        <input
-          v-model="matchText"
-          type="text"
-          class="form-control"
-          id="inlineSearch"
-          placeholder="Search for incident/package"
-        />
-        <input
-          v-model="groupNames"
-          type="text"
-          class="form-control"
-          id="inlineSearch"
-          placeholder="Search for group names"
-        />
-      </div>
       <div class="col-auto my-1">
         <div class="form-check">
           <input class="form-check-input" type="checkbox" id="checkbox" v-model="groupFlavors" />
@@ -29,8 +12,28 @@
     <table class="table">
       <thead>
         <tr>
-          <th>Incident</th>
-          <th>Groups</th>
+          <th>
+            Incident
+            <input
+              v-model="matchText"
+              type="text"
+              class="form-control"
+              id="inlineSearch"
+              title="Partial incident# or package name are matched"
+              placeholder="Search for incident/package"
+            />
+          </th>
+          <th>
+            Groups
+            <input
+              v-model="groupNames"
+              type="text"
+              class="form-control"
+              id="inlineSearch"
+              title="Only exact, comma separated, job group names are matched"
+              placeholder="Search for group names"
+            />
+          </th>
         </tr>
       </thead>
       <tbody>

--- a/assets/vue/components/PageBlocked.vue
+++ b/assets/vue/components/PageBlocked.vue
@@ -68,7 +68,7 @@ export default {
   },
   computed: {
     matchedIncidents() {
-      let results = [];
+      let results = this.incidents;
       if (this.matchText) {
         results = this.incidents.filter(incident => {
           if (String(incident.incident.number).includes(this.matchText)) return true;
@@ -77,12 +77,10 @@ export default {
           }
           return false;
         });
-      } else {
-        results = this.incidents;
       }
       if (this.groupNames) {
+        const groupNamesList = this.groupNames.toLowerCase().split(',');
         return results.filter(incident => {
-          const groupNamesList = this.groupNames.toLowerCase().split(',');
           for (const key of Object.keys(incident.update_results)) {
             for (const groupName of Object.values(groupNamesList)) {
               if (groupName.toLowerCase() === incident.update_results[key].name.toLowerCase()) return true;

--- a/assets/vue/components/PageBlocked.vue
+++ b/assets/vue/components/PageBlocked.vue
@@ -9,14 +9,14 @@
           type="text"
           class="form-control"
           id="inlineSearch"
-          placeholder="Search for Incident/Package"
+          placeholder="Search for incident/package"
         />
         <input
           v-model="groupNames"
           type="text"
           class="form-control"
           id="inlineSearch"
-          placeholder="Search for Group Names"
+          placeholder="Search for group names"
         />
       </div>
       <div class="col-auto my-1">
@@ -68,7 +68,7 @@ export default {
   },
   computed: {
     matchedIncidents() {
-      var results = [];
+      let results = [];
       if (this.matchText) {
         results = this.incidents.filter(incident => {
           if (String(incident.incident.number).includes(this.matchText)) return true;
@@ -82,14 +82,15 @@ export default {
       }
       if (this.groupNames) {
         return results.filter(incident => {
-          for (let key in incident.update_results) {
-            for (let groupName of this.groupNames.split(',')) {
-              if (groupName.toLowerCase() == incident.update_results[key].name.toLowerCase()) return true;
+          const groupNamesList = this.groupNames.toLowerCase().split(',');
+          for (const key of Object.keys(incident.update_results)) {
+            for (const groupName of Object.values(groupNamesList)) {
+              if (groupName.toLowerCase() === incident.update_results[key].name.toLowerCase()) return true;
             }
           }
-          for (let key in incident.incident_results) {
-            for (let groupName of this.groupNames.split(',')) {
-              if (groupName.toLowerCase() == incident.incident_results[key].name.toLowerCase()) return true;
+          for (const key of Object.keys(incident.incident_results)) {
+            for (const groupName of Object.values(groupNamesList)) {
+              if (groupName.toLowerCase() === incident.incident_results[key].name.toLowerCase()) return true;
             }
           }
           return false;

--- a/assets/vue/components/PageBlocked.vue
+++ b/assets/vue/components/PageBlocked.vue
@@ -18,7 +18,7 @@
               v-model="matchText"
               type="text"
               class="form-control"
-              id="inlineSearch"
+              id="inlineSearchIncidents"
               title="Partial incident# or package name are matched"
               placeholder="Search for incident/package"
             />
@@ -29,7 +29,7 @@
               v-model="groupNames"
               type="text"
               class="form-control"
-              id="inlineSearch"
+              id="inlineSearchGroups"
               title="Only exact, comma separated, job group names are matched"
               placeholder="Search for group names"
             />
@@ -86,12 +86,12 @@ export default {
         return results.filter(incident => {
           for (const key of Object.keys(incident.update_results)) {
             for (const groupName of Object.values(groupNamesList)) {
-              if (groupName.toLowerCase() === incident.update_results[key].name.toLowerCase()) return true;
+              if (groupName === incident.update_results[key].name.toLowerCase()) return true;
             }
           }
           for (const key of Object.keys(incident.incident_results)) {
             for (const groupName of Object.values(groupNamesList)) {
-              if (groupName.toLowerCase() === incident.incident_results[key].name.toLowerCase()) return true;
+              if (groupName === incident.incident_results[key].name.toLowerCase()) return true;
             }
           }
           return false;

--- a/assets/vue/components/PageBlocked.vue
+++ b/assets/vue/components/PageBlocked.vue
@@ -11,6 +11,13 @@
           id="inlineSearch"
           placeholder="Search for Incident/Package"
         />
+        <input
+          v-model="groupNames"
+          type="text"
+          class="form-control"
+          id="inlineSearch"
+          placeholder="Search for Group Names"
+        />
       </div>
       <div class="col-auto my-1">
         <div class="form-check">
@@ -34,6 +41,7 @@
           :incident-results="incident.incident_results"
           :update-results="incident.update_results"
           :group-flavors="groupFlavors"
+          :group-names="groupNames"
         />
       </tbody>
     </table>
@@ -54,21 +62,40 @@ export default {
       incidents: null,
       groupFlavors: true,
       matchText: '',
+      groupNames: '',
       refreshUrl: '/app/api/blocked'
     };
   },
   computed: {
     matchedIncidents() {
+      var results = [];
       if (this.matchText) {
-        return this.incidents.filter(incident => {
+        results = this.incidents.filter(incident => {
           if (String(incident.incident.number).includes(this.matchText)) return true;
           for (const pack of incident.incident.packages) {
             if (pack.includes(this.matchText)) return true;
           }
           return false;
         });
+      } else {
+        results = this.incidents;
       }
-      return this.incidents;
+      if (this.groupNames) {
+        return results.filter(incident => {
+          for (let key in incident.update_results) {
+            for (let groupName of this.groupNames.split(',')) {
+              if (groupName.toLowerCase() == incident.update_results[key].name.toLowerCase()) return true;
+            }
+          }
+          for (let key in incident.incident_results) {
+            for (let groupName of this.groupNames.split(',')) {
+              if (groupName.toLowerCase() == incident.incident_results[key].name.toLowerCase()) return true;
+            }
+          }
+          return false;
+        });
+      }
+      return results;
     },
     smelt() {
       return this.appConfig.smeltUrl;

--- a/t/ui.t.js
+++ b/t/ui.t.js
@@ -69,7 +69,7 @@ t.test('Test dashboard ui', skip, async t => {
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(1) a'), /16860:perl-Mojolicious/);
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 1/);
 
-    await page.fill('[placeholder="Search for Incident/Package"]', 'curl');
+    await page.fill('[placeholder="Search for incident/package"]', 'curl');
     t.equal(await list.count(), 0);
   });
 

--- a/t/ui.t.js
+++ b/t/ui.t.js
@@ -71,6 +71,18 @@ t.test('Test dashboard ui', skip, async t => {
 
     await page.fill('[placeholder="Search for incident/package"]', 'curl');
     t.equal(await list.count(), 0);
+
+    await page.fill('[placeholder="Search for incident/package"]', 'perl');
+    t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
+    t.equal(await list.count(), 1);
+
+    await page.fill('[placeholder="Search for group names"]', 'SLE');
+    t.equal(await list.count(), 0);
+
+    await page.fill('[placeholder="Search for group names"]', 'SLE 12 SP5');
+    t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5/);
+    t.notMatch(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
+    t.equal(await list.count(), 1);
   });
 
   await t.test('Incident popup', async t => {


### PR DESCRIPTION
- Allow to filter for multiple job groups, separated by ','

Follow-up to continue discussion from https://github.com/openSUSE/qem-dashboard/pull/302