### PR TITLE
Add a simple script to add fixtures to the (local) database

### DIFF
--- a/add-fixtures-to-database.pl
+++ b/add-fixtures-to-database.pl
@@ -1,0 +1,11 @@
+use Mojo::Base -strict, -signatures;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/t/lib";
+
+use Dashboard;
+use Dashboard::Test;
+
+my $t = Dashboard::Test->new(online => $ARGV[0] // 'postgresql:///dashboard');
+my $d = Dashboard->new;
+$t->minimal_fixtures($d);

--- a/t/lib/Dashboard/Test.pm
+++ b/t/lib/Dashboard/Test.pm
@@ -359,6 +359,7 @@ sub postgres_url ($self) {
 }
 
 sub _prepare_schema ($self, $name) {
+  return undef unless $name;
 
   # Isolate tests
   my $pg = $self->{pg};


### PR DESCRIPTION
This is useful for development as it allows to explore/use the fixtures used by unit/integration tests when starting the app normally via `mojo webpack script/dashboard`.