### PR TITLE
Make filtering on blocked page accessible via query parameters

### DIFF
--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -25,6 +25,7 @@
 </template>
 
 <script>
+import * as filtering from '../helpers/filtering.js';
 import BlockedIncidentIncResult from './BlockedIncidentIncResult.vue';
 import BlockedIncidentUpdResult from './BlockedIncidentUpdResult.vue';
 import IncidentLink from './IncidentLink.vue';
@@ -47,13 +48,13 @@ export default {
     updateResultsGrouped() {
       if (!this.groupFlavors) return this.updateResults;
       const results = {};
-      const groupNamesList = this.groupNames.toLowerCase().split(',');
+      const filters = filtering.makeGroupNamesFilters(this.groupNames);
       for (const value of Object.values(this.updateResults)) {
         const {flavor} = value.linkinfo;
         const {version} = value.linkinfo;
         const {groupid} = value.linkinfo;
         const newkey = `${groupid}:${version}`;
-        if (groupNamesList.includes(value.name.toLowerCase()) || this.groupNames === '') {
+        if (this.groupNames === '' || filtering.checkResult(value, filters)) {
           const res = (results[newkey] = {
             name: value.name,
             passed: 0,
@@ -74,9 +75,9 @@ export default {
     incidentResultsGrouped() {
       if (this.groupNames === '') return this.incidentResults;
       const results = [];
-      const groupNamesList = this.groupNames.toLowerCase().split(',');
+      const filters = filtering.makeGroupNamesFilters(this.groupNames);
       for (const value of Object.values(this.incidentResults)) {
-        if (groupNamesList.includes(value.name.toLowerCase())) results.push(value);
+        if (filtering.checkResult(value, filters)) results.push(value);
       }
       return results;
     }

--- a/assets/vue/components/PageBlocked.vue
+++ b/assets/vue/components/PageBlocked.vue
@@ -30,7 +30,7 @@
               type="text"
               class="form-control"
               id="inlineSearchGroups"
-              title="Only exact, comma separated, job group names are matched"
+              title="Comma separated, job group names are matched, supports regex syntax"
               placeholder="Search for group names"
             />
           </th>
@@ -53,6 +53,7 @@
 </template>
 
 <script>
+import * as filtering from '../helpers/filtering.js';
 import Refresh from '../mixins/refresh.js';
 import BlockedIncident from './BlockedIncident.vue';
 
@@ -82,20 +83,12 @@ export default {
         });
       }
       if (this.groupNames) {
-        const groupNamesList = this.groupNames.toLowerCase().split(',');
-        return results.filter(incident => {
-          for (const key of Object.keys(incident.update_results)) {
-            for (const groupName of Object.values(groupNamesList)) {
-              if (groupName === incident.update_results[key].name.toLowerCase()) return true;
-            }
-          }
-          for (const key of Object.keys(incident.incident_results)) {
-            for (const groupName of Object.values(groupNamesList)) {
-              if (groupName === incident.incident_results[key].name.toLowerCase()) return true;
-            }
-          }
-          return false;
-        });
+        const filters = filtering.makeGroupNamesFilters(this.groupNames);
+        return results.filter(
+          incident =>
+            filtering.checkResults(incident.update_results, filters) ||
+            filtering.checkResults(incident.incident_results, filters)
+        );
       }
       return results;
     },

--- a/assets/vue/helpers/filtering.js
+++ b/assets/vue/helpers/filtering.js
@@ -1,0 +1,20 @@
+export function makeGroupNamesFilters(groupNames) {
+  return groupNames
+    .toLowerCase()
+    .split(',')
+    .map(groupName => new RegExp(groupName));
+}
+
+export function checkResult(result, filters) {
+  for (const filter of filters) {
+    if (filter.test(result.name.toLowerCase())) return true;
+  }
+  return false;
+}
+
+export function checkResults(results, filters) {
+  for (const result of Object.values(results)) {
+    if (checkResult(result, filters)) return true;
+  }
+  return false;
+}

--- a/t/ui.t.js
+++ b/t/ui.t.js
@@ -85,10 +85,15 @@ t.test('Test dashboard ui', skip, async t => {
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
     t.equal(await list.count(), 1);
 
-    await page.fill('[placeholder="Search for group names"]', 'SLE');
+    await page.fill('[placeholder="Search for group names"]', 'SLE$');
     t.equal(await list.count(), 0);
 
     await page.fill('[placeholder="Search for group names"]', 'SLE 12 SP5');
+    t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5/);
+    t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
+    t.equal(await list.count(), 1);
+
+    await page.fill('[placeholder="Search for group names"]', 'SLE 12 SP5$');
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5/);
     t.notMatch(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
     t.equal(await list.count(), 1);

--- a/t/ui.t.js
+++ b/t/ui.t.js
@@ -77,13 +77,20 @@ t.test('Test dashboard ui', skip, async t => {
     t.equal(await list.count(), 1);
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(1) a'), /16860:perl-Mojolicious/);
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 1/);
+    const pageUrl = await page.url();
+    t.notMatch(pageUrl, /incident/);
+    t.notMatch(pageUrl, /group_names/);
+    t.notMatch(pageUrl, /group_flavors/);
 
     await page.fill('[placeholder="Search for incident/package"]', 'curl');
     t.equal(await list.count(), 0);
+    t.match(await page.url(), /incident=curl/);
 
     await page.fill('[placeholder="Search for incident/package"]', 'perl');
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
     t.equal(await list.count(), 1);
+    t.notMatch(await page.url(), /incident=curl/);
+    t.match(await page.url(), /incident=perl/);
 
     await page.fill('[placeholder="Search for group names"]', 'SLE$');
     t.equal(await list.count(), 0);
@@ -92,11 +99,18 @@ t.test('Test dashboard ui', skip, async t => {
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5/);
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
     t.equal(await list.count(), 1);
+    t.match(await page.url(), /incident=perl/);
+    t.match(await page.url(), /group_names=SLE\+12\+SP5/);
 
     await page.fill('[placeholder="Search for group names"]', 'SLE 12 SP5$');
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5/);
     t.notMatch(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SLE 12 SP5 Kernel/);
     t.equal(await list.count(), 1);
+
+    await page.goto(`${url}/blocked?incident=foo&group_flavors=0&group_names=bar`);
+    t.equal(await page.getByPlaceholder('Search for incident/package').inputValue(), 'foo');
+    t.equal(await page.getByPlaceholder('Search for group names').inputValue(), 'bar');
+    t.ok(!(await page.getByLabel('Group Flavors').isChecked()));
   });
 
   await t.test('Incident popup', async t => {


### PR DESCRIPTION
* Based on #355 which is included. Check the commit "Make filtering …" for just the relevant change.
* The "blocked" page is used by Kernel QE but "Unfortunately, wild cards are not supported, it is not possible to create bookmark with search query" (quote from [their confluence page](https://confluence.suse.com/pages/viewpage.action?spaceKey=qasle&title=Kernel+QE+maintenance+job+groups+review)). This PR and its base #355 address these issues.
* See https://progress.opensuse.org/issues/127208