### PR TITLE
Filter groups on blocked page also when "Group flavors" disabled

### DIFF
--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -46,7 +46,6 @@ export default {
   },
   computed: {
     updateResultsGrouped() {
-      if (!this.groupFlavors) return this.updateResults;
       const results = {};
       const filters = filtering.makeGroupNamesFilters(this.groupNames);
       for (const value of Object.values(this.updateResults)) {


### PR DESCRIPTION
That we don't hide groups not matching the filter when "Group flavors" is disabled seems like a bug, e.g.
https://github.com/openSUSE/qem-dashboard/pull/357#issuecomment-1709989630. This change applies the filter regardless of the "Group flavors" setting.