### PR TITLE
Remove distri filter on dashboard blocked page

### DIFF
--- a/assets/vue/components/ResultSummary.vue
+++ b/assets/vue/components/ResultSummary.vue
@@ -32,6 +32,7 @@ export default {
           searchParams.append('flavor', flavor);
         });
       }
+      searchParams.delete('distri');
       return `${this.appConfig.openqaUrl}?${searchParams.toString()}`;
     },
     stopped() {


### PR DESCRIPTION
https://progress.opensuse.org/issues/138068

Remove distribution filter to allow either sle or opensuse tests to be shown by openqa link