### PR TITLE
Revert "Bump vue from 3.4.0 to 3.4.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "sass-loader": "^13.3.2",
         "tap": "^18.6.1",
         "terser-webpack-plugin": "^5.3.6",
-        "vue": "^3.4.3",
+        "vue": "^3.4.0",
         "vue-loader": "^17.4.0",
         "vue-router": "^4.2.5",
         "vue-template-compiler": "^2.7.16",
@@ -3386,36 +3386,36 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.3.tgz",
-      "integrity": "sha512-u8jzgFg0EDtSrb/hG53Wwh1bAOQFtc1ZCegBpA/glyvTlgHl+tq13o1zvRfLbegYUw/E4mSTGOiCnAJ9SJ+lsg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.0.tgz",
+      "integrity": "sha512-cw4S15PkNGTKkP9OFFl4wnQoJJk+HqaYBafgrpDnSukiQGpcYJeRpzmqnCVCIkl6V6Eqsv58E0OAdl6b592vuA==",
       "dependencies": {
         "@babel/parser": "^7.23.6",
-        "@vue/shared": "3.4.3",
+        "@vue/shared": "3.4.0",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.3.tgz",
-      "integrity": "sha512-oGF1E9/htI6JWj/lTJgr6UgxNCtNHbM6xKVreBWeZL9QhRGABRVoWGAzxmtBfSOd+w0Zi5BY0Es/tlJrN6WgEg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.0.tgz",
+      "integrity": "sha512-E957uOhpoE48YjZGWeAoLmNYd3UeU4oIP8kJi8Rcsb9l2tV8Z48Jn07Zgq1aW0v3vuhlmydEKkKKbhLpADHXEA==",
       "dependencies": {
-        "@vue/compiler-core": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-core": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.3.tgz",
-      "integrity": "sha512-NuJqb5is9I4uzv316VRUDYgIlPZCG8D+ARt5P4t5UDShIHKL25J3TGZAUryY/Aiy0DsY7srJnZL5ryB6DD63Zw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.0.tgz",
+      "integrity": "sha512-PWE0mE2yW7bJS7PmaCrVDEG6KPaDJo0pb4AKnCxJ5lRRDO4IwL/fswBGhCpov+v/c+N/e+hQHpXNwvqU9BtUXg==",
       "dependencies": {
         "@babel/parser": "^7.23.6",
-        "@vue/compiler-core": "3.4.3",
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/compiler-ssr": "3.4.3",
-        "@vue/shared": "3.4.3",
+        "@vue/compiler-core": "3.4.0",
+        "@vue/compiler-dom": "3.4.0",
+        "@vue/compiler-ssr": "3.4.0",
+        "@vue/shared": "3.4.0",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
         "postcss": "^8.4.32",
@@ -3423,12 +3423,12 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.3.tgz",
-      "integrity": "sha512-wnYQtMBkeFSxgSSQbYGQeXPhQacQiog2c6AlvMldQH6DB+gSXK/0F6DVXAJfEiuBSgBhUc8dwrrG5JQcqwalsA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.0.tgz",
+      "integrity": "sha512-+oXKy105g9DIYQKDi3Gwung0xqQX5gJHr0GR+Vf7yK/WkNDM6q61ummcKmKAB85EIst8y3vj2PA9z9YU5Oc4DQ==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-dom": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -3437,48 +3437,48 @@
       "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.3.tgz",
-      "integrity": "sha512-q5f9HLDU+5aBKizXHAx0w4whkIANs1Muiq9R5YXm0HtorSlflqv9u/ohaMxuuhHWCji4xqpQ1eL04WvmAmGnFg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.0.tgz",
+      "integrity": "sha512-X6BvQjNcgKKHWPQzlRJjZvIu72Kkn8xJSv6VNptqWh8dToMknD0Hch1l4N7llKgVt6Diq4lMeUnErbZFvuGlAA==",
       "dependencies": {
-        "@vue/shared": "3.4.3"
+        "@vue/shared": "3.4.0"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.3.tgz",
-      "integrity": "sha512-C1r6QhB1qY7D591RCSFhMULyzL9CuyrGc+3PpB0h7dU4Qqw6GNyo4BNFjHZVvsWncrUlKX3DIKg0Y7rNNr06NQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.0.tgz",
+      "integrity": "sha512-NYrj/JgMMqnSWcIud8lLzDQrBLu+EVEeQ56QE9DYJeKG2eFrnQy8o/h57R9nCprafHs0uImKL3xsdXjHseYVxw==",
       "dependencies": {
-        "@vue/reactivity": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/reactivity": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.3.tgz",
-      "integrity": "sha512-wrsprg7An5Ec+EhPngWdPuzkp0BEUxAKaQtN9dPU/iZctPyD9aaXmVtehPJerdQxQale6gEnhpnfywNw3zOv2A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.0.tgz",
+      "integrity": "sha512-1ZoHEsA5l77qbx2F+SWo/hQdBksPuOmww1t/jznidDG+xMB/iidafEFvo2ZTtZii0JfTIrlDhjshfYUvQC17wQ==",
       "dependencies": {
-        "@vue/runtime-core": "3.4.3",
-        "@vue/shared": "3.4.3",
+        "@vue/runtime-core": "3.4.0",
+        "@vue/shared": "3.4.0",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.3.tgz",
-      "integrity": "sha512-BUxt8oVGMKKsqSkM1uU3d3Houyfy4WAc2SpSQRebNd+XJGATVkW/rO129jkyL+kpB/2VRKzE63zwf5RtJ3XuZw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.0.tgz",
+      "integrity": "sha512-GuOVCyLDlWPu8nKo5AUxb8B+iB/Ik4I1WwqAlBqf5+y48z6D6rvKshp7KR3cJea+pte1tdTsb0+Ja82KizMZOw==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-ssr": "3.4.0",
+        "@vue/shared": "3.4.0"
       },
       "peerDependencies": {
-        "vue": "3.4.3"
+        "vue": "3.4.0"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.3.tgz",
-      "integrity": "sha512-rIwlkkP1n4uKrRzivAKPZIEkHiuwY5mmhMJ2nZKCBLz8lTUlE73rQh4n1OnnMurXt1vcUNyH4ZPfdh8QweTjpQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.0.tgz",
+      "integrity": "sha512-Nhh3ed3G1R6HDAWiG6YYFt0Zmq/To6u5vjzwa9TIquGheCXPY6nEdIAO8ZdlwXsWqC2yNLj700FOvShpYt5CEA=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -11142,15 +11142,15 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.3.tgz",
-      "integrity": "sha512-GjN+culMAGv/mUbkIv8zMKItno8npcj5gWlXkSxf1SPTQf8eJ4A+YfHIvQFyL1IfuJcMl3soA7SmN1fRxbf/wA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.0.tgz",
+      "integrity": "sha512-iTE9Ve/7DO/H39+gXHrNkRdnh1jDwPe/fap4brbPKkp1APMkS03OiZ+UY0dwpqtRX0iPWQTkh8Fu3hKgLtaxfA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/compiler-sfc": "3.4.3",
-        "@vue/runtime-dom": "3.4.3",
-        "@vue/server-renderer": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-dom": "3.4.0",
+        "@vue/compiler-sfc": "3.4.0",
+        "@vue/runtime-dom": "3.4.0",
+        "@vue/server-renderer": "3.4.0",
+        "@vue/shared": "3.4.0"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -14121,36 +14121,36 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "@vue/compiler-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.3.tgz",
-      "integrity": "sha512-u8jzgFg0EDtSrb/hG53Wwh1bAOQFtc1ZCegBpA/glyvTlgHl+tq13o1zvRfLbegYUw/E4mSTGOiCnAJ9SJ+lsg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.0.tgz",
+      "integrity": "sha512-cw4S15PkNGTKkP9OFFl4wnQoJJk+HqaYBafgrpDnSukiQGpcYJeRpzmqnCVCIkl6V6Eqsv58E0OAdl6b592vuA==",
       "requires": {
         "@babel/parser": "^7.23.6",
-        "@vue/shared": "3.4.3",
+        "@vue/shared": "3.4.0",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.3.tgz",
-      "integrity": "sha512-oGF1E9/htI6JWj/lTJgr6UgxNCtNHbM6xKVreBWeZL9QhRGABRVoWGAzxmtBfSOd+w0Zi5BY0Es/tlJrN6WgEg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.0.tgz",
+      "integrity": "sha512-E957uOhpoE48YjZGWeAoLmNYd3UeU4oIP8kJi8Rcsb9l2tV8Z48Jn07Zgq1aW0v3vuhlmydEKkKKbhLpADHXEA==",
       "requires": {
-        "@vue/compiler-core": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-core": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.3.tgz",
-      "integrity": "sha512-NuJqb5is9I4uzv316VRUDYgIlPZCG8D+ARt5P4t5UDShIHKL25J3TGZAUryY/Aiy0DsY7srJnZL5ryB6DD63Zw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.0.tgz",
+      "integrity": "sha512-PWE0mE2yW7bJS7PmaCrVDEG6KPaDJo0pb4AKnCxJ5lRRDO4IwL/fswBGhCpov+v/c+N/e+hQHpXNwvqU9BtUXg==",
       "requires": {
         "@babel/parser": "^7.23.6",
-        "@vue/compiler-core": "3.4.3",
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/compiler-ssr": "3.4.3",
-        "@vue/shared": "3.4.3",
+        "@vue/compiler-core": "3.4.0",
+        "@vue/compiler-dom": "3.4.0",
+        "@vue/compiler-ssr": "3.4.0",
+        "@vue/shared": "3.4.0",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
         "postcss": "^8.4.32",
@@ -14158,12 +14158,12 @@
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.3.tgz",
-      "integrity": "sha512-wnYQtMBkeFSxgSSQbYGQeXPhQacQiog2c6AlvMldQH6DB+gSXK/0F6DVXAJfEiuBSgBhUc8dwrrG5JQcqwalsA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.0.tgz",
+      "integrity": "sha512-+oXKy105g9DIYQKDi3Gwung0xqQX5gJHr0GR+Vf7yK/WkNDM6q61ummcKmKAB85EIst8y3vj2PA9z9YU5Oc4DQ==",
       "requires": {
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-dom": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "@vue/devtools-api": {
@@ -14172,45 +14172,45 @@
       "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
     },
     "@vue/reactivity": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.3.tgz",
-      "integrity": "sha512-q5f9HLDU+5aBKizXHAx0w4whkIANs1Muiq9R5YXm0HtorSlflqv9u/ohaMxuuhHWCji4xqpQ1eL04WvmAmGnFg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.0.tgz",
+      "integrity": "sha512-X6BvQjNcgKKHWPQzlRJjZvIu72Kkn8xJSv6VNptqWh8dToMknD0Hch1l4N7llKgVt6Diq4lMeUnErbZFvuGlAA==",
       "requires": {
-        "@vue/shared": "3.4.3"
+        "@vue/shared": "3.4.0"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.3.tgz",
-      "integrity": "sha512-C1r6QhB1qY7D591RCSFhMULyzL9CuyrGc+3PpB0h7dU4Qqw6GNyo4BNFjHZVvsWncrUlKX3DIKg0Y7rNNr06NQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.0.tgz",
+      "integrity": "sha512-NYrj/JgMMqnSWcIud8lLzDQrBLu+EVEeQ56QE9DYJeKG2eFrnQy8o/h57R9nCprafHs0uImKL3xsdXjHseYVxw==",
       "requires": {
-        "@vue/reactivity": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/reactivity": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.3.tgz",
-      "integrity": "sha512-wrsprg7An5Ec+EhPngWdPuzkp0BEUxAKaQtN9dPU/iZctPyD9aaXmVtehPJerdQxQale6gEnhpnfywNw3zOv2A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.0.tgz",
+      "integrity": "sha512-1ZoHEsA5l77qbx2F+SWo/hQdBksPuOmww1t/jznidDG+xMB/iidafEFvo2ZTtZii0JfTIrlDhjshfYUvQC17wQ==",
       "requires": {
-        "@vue/runtime-core": "3.4.3",
-        "@vue/shared": "3.4.3",
+        "@vue/runtime-core": "3.4.0",
+        "@vue/shared": "3.4.0",
         "csstype": "^3.1.3"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.3.tgz",
-      "integrity": "sha512-BUxt8oVGMKKsqSkM1uU3d3Houyfy4WAc2SpSQRebNd+XJGATVkW/rO129jkyL+kpB/2VRKzE63zwf5RtJ3XuZw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.0.tgz",
+      "integrity": "sha512-GuOVCyLDlWPu8nKo5AUxb8B+iB/Ik4I1WwqAlBqf5+y48z6D6rvKshp7KR3cJea+pte1tdTsb0+Ja82KizMZOw==",
       "requires": {
-        "@vue/compiler-ssr": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-ssr": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "@vue/shared": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.3.tgz",
-      "integrity": "sha512-rIwlkkP1n4uKrRzivAKPZIEkHiuwY5mmhMJ2nZKCBLz8lTUlE73rQh4n1OnnMurXt1vcUNyH4ZPfdh8QweTjpQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.0.tgz",
+      "integrity": "sha512-Nhh3ed3G1R6HDAWiG6YYFt0Zmq/To6u5vjzwa9TIquGheCXPY6nEdIAO8ZdlwXsWqC2yNLj700FOvShpYt5CEA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -19492,15 +19492,15 @@
       }
     },
     "vue": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.3.tgz",
-      "integrity": "sha512-GjN+culMAGv/mUbkIv8zMKItno8npcj5gWlXkSxf1SPTQf8eJ4A+YfHIvQFyL1IfuJcMl3soA7SmN1fRxbf/wA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.0.tgz",
+      "integrity": "sha512-iTE9Ve/7DO/H39+gXHrNkRdnh1jDwPe/fap4brbPKkp1APMkS03OiZ+UY0dwpqtRX0iPWQTkh8Fu3hKgLtaxfA==",
       "requires": {
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/compiler-sfc": "3.4.3",
-        "@vue/runtime-dom": "3.4.3",
-        "@vue/server-renderer": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-dom": "3.4.0",
+        "@vue/compiler-sfc": "3.4.0",
+        "@vue/runtime-dom": "3.4.0",
+        "@vue/server-renderer": "3.4.0",
+        "@vue/shared": "3.4.0"
       }
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sass-loader": "^13.3.2",
     "tap": "^18.6.1",
     "terser-webpack-plugin": "^5.3.6",
-    "vue": "^3.4.3",
+    "vue": "^3.4.0",
     "vue-loader": "^17.4.0",
     "vue-router": "^4.2.5",
     "vue-template-compiler": "^2.7.16",


### PR DESCRIPTION
Reverts openSUSE/qem-dashboard#731

See: https://progress.opensuse.org/issues/153003
