### PR TITLE
Add Makefile for convenience

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,31 +31,17 @@ jobs:
           node-version: '18'
       - name: node -v
         run: node -v
-      - name: npm install
-        run: npm i
-      - name: Install playwright browsers
-        run: npx playwright install --with-deps
+      - name: Install JS dependencies
+        run: make install-deps-js
       - name: perl -V
         run: perl -V
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libmagic-dev ruby-sass
-          cpanm -n --installdeps .
-          cpanm -n Test::Deep
-          cpanm -n Devel::Cover::Report::Coveralls
+          make install-deps-ubuntu install-deps-cpanm
       - name: Run tests
-        env:
-          MOJO_MODE: production
-          TEST_ONLINE: postgresql://postgres:postgres@localhost:5432/postgres
-          HARNESS_PERL_SWITCHES: -MDevel::Cover
-        run: prove -l t/*.t
+        run: make test-unit
       - name: Run UI tests
-        env:
-          MOJO_MODE: production
-          TEST_ONLINE: postgresql://postgres:postgres@localhost:5432/postgres
-          TEST_WRAPPER_COVERAGE: 1
-        run: prove -l -v t/*.t.js
+        run: make test-ui
       - name: Check assets
         run: ls public/asset
       - name: Coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ assets/assetpack.db
 assets/cache
 public/asset
 node_modules
+cover_db/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+.PHONY: all
+all: help
+
+.PHONY: help
+help:
+	@echo Call one of the available targets:
+	@sed -n 's/\(^[^.#[:space:]A-Z]*\):.*$$/\1/p' Makefile | uniq
+	@echo See README.md for more details
+
+.PHONY: install-deps-js
+install-deps-js:
+	npm install
+	npx playwright install --with-deps
+
+.PHONY: install-deps-ubuntu
+install-deps-ubuntu:
+	sudo apt-get update
+	sudo apt-get install -y libmagic-dev ruby-sass
+
+.PHONY: install-deps-cpanm
+install-deps-cpanm:
+	cpanm -n --installdeps .
+	cpanm -n Test::Deep
+	cpanm -n Devel::Cover::Report::Coveralls
+
+.PHONY: install-deps
+install-deps: install-deps-js install-deps-ubuntu install-deps-cpanm
+
+.PHONY: test-unit
+test-unit:
+	MOJO_MODE=production \
+	TEST_ONLINE=postgresql://postgres:postgres@localhost:5432/postgres \
+	HARNESS_PERL_SWITCHES=-MDevel::Cover \
+	prove -l t/*.t
+
+.PHONY: test-ui
+test-ui:
+	MOJO_MODE=production \
+	TEST_ONLINE=postgresql://postgres:postgres@localhost:5432/postgres \
+	TEST_WRAPPER_COVERAGE=1 \
+	prove -l -v t/*.t.js
+
+.PHONY: test
+test: test-unit test-ui


### PR DESCRIPTION
New developers would have a hard time finding necessary dependencies and
commands to execute by needing to look into GHA definitions so instead
let's provide a convenient Makefile with help text.