### PR TITLE
Highlight blocked incidents with a priority above 650

### DIFF
--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -1,7 +1,7 @@
 <template>
-  <tr>
+  <tr :class="{'high-priority': incident.priority > 650}">
     <td>
-      <IncidentLink :incident="incident" />
+      <IncidentLink :incident="incident" :high-priority="incident.priority > 650" />
     </td>
     <td>
       <div v-if="Object.keys(incidentResults).length + Object.keys(updateResults).length === 0">No data yet</div>
@@ -87,3 +87,21 @@ export default {
   }
 };
 </script>
+
+<style>
+.high-priority {
+  background: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 10px,
+    var(--bs-warning-bg-subtle) 10px,
+    var(--bs-warning-bg-subtle) 20px
+  );
+  td {
+    background-color: initial;
+  }
+  td:nth-child(1) a {
+    font-weight: bold;
+  }
+}
+</style>

--- a/assets/vue/components/IncidentLink.vue
+++ b/assets/vue/components/IncidentLink.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
-    <router-link class="incident-link" :to="{name: 'incident', params: {id: incident.number}}">
+    <router-link
+      class="incident-link"
+      :to="{name: 'incident', params: {id: incident.number}}"
+      :title="highPriority ? 'Incident with priority > 650: Focus on review and consider manual approval' : ''"
+    >
       {{ incident.number }}:{{ packageName }}
+      <i v-if="highPriority" class="fas fa-triangle-exclamation"></i>
     </router-link>
   </div>
 </template>
@@ -9,7 +14,7 @@
 <script>
 export default {
   name: 'IncidentLink',
-  props: {incident: {type: Object, required: true}},
+  props: {incident: {type: Object, required: true}, highPriority: {type: Boolean, default: false}},
   computed: {
     packageName() {
       return this.incident.packages[0];

--- a/t/json.t
+++ b/t/json.t
@@ -94,7 +94,7 @@ subtest 'List incidents' => sub {
         "isActive"    => 1,
         "number"      => 29722,
         "packages"    => ["multipath-tools"],
-        "priority"    => 100,
+        "priority"    => 700,
         "project"     => "SUSE:Maintenance:29722 ",
         "rr_number"   => 302772
       }
@@ -162,7 +162,7 @@ subtest 'Blocked by Tests' => sub {
           "id"         => 4,
           "number"     => 29722,
           "packages"   => ["multipath-tools"],
-          "priority"   => 100,
+          "priority"   => 700,
           "project"    => "SUSE:Maintenance:29722 ",
           "review"     => 1,
           "review_qam" => 1,

--- a/t/lib/Dashboard/Test.pm
+++ b/t/lib/Dashboard/Test.pm
@@ -124,7 +124,8 @@ sub minimal_fixtures ($self, $app) {
         emu         => false,
         embargoed   => false,
         isActive    => true,
-        priority    => 100,      # highest priority; supposed to show first on "Blocked" page
+        priority    => 700
+        , # highest priority; supposed to show first on "Blocked" page and be highlighted for manual review as priority is above threshhold
       },
     ]
   );

--- a/t/ui.t.js
+++ b/t/ui.t.js
@@ -73,7 +73,7 @@ t.test('Test dashboard ui', skip, async t => {
     t.match(await page.innerText('.incident-results mark'), /1 passed, 1 waiting/);
   });
 
-  await t.test('Sorting and filtering on "Blocked" page', async t => {
+  await t.test('Sorting, highlighting and filtering on "Blocked" page', async t => {
     await page.goto(`${url}/blocked`);
     await page.waitForSelector('tbody');
     const list = page.locator('tbody > tr');
@@ -82,6 +82,7 @@ t.test('Test dashboard ui', skip, async t => {
     t.match(await page.innerText('tbody tr:nth-of-type(1) td:nth-of-type(2)'), /SAP\/HA Maintenance 1\/5/);
     t.match(await page.innerText('tbody tr:nth-of-type(2) td:nth-of-type(1) a'), /16860:perl-Mojolicious/);
     t.match(await page.innerText('tbody tr:nth-of-type(2) td:nth-of-type(2)'), /SLE 12 SP5 1/);
+    t.match(await page.innerText('tbody tr.high-priority'), /29722:multipath-tools/);
     const pageUrl = await page.url();
     t.notMatch(pageUrl, /incident/);
     t.notMatch(pageUrl, /group_names/);


### PR DESCRIPTION
Related Ticket: [163586](https://progress.opensuse.org/issues/163586)
This PR adds highlighting (orange background) for incident on the "/blocked" page  if they have a priority value above 650.

![Screenshot from 2024-07-30 16-04-08](https://github.com/user-attachments/assets/d593772c-fd22-4cc1-ac48-efaca947db64)

![Screenshot from 2024-07-30 16-24-58](https://github.com/user-attachments/assets/f995563d-1ae5-4d03-a414-6285d74ef35d)

