### PR TITLE
Fix highlighting bold+pattern for older browsers

### DIFF
--- a/assets/vue/components/BlockedIncident.vue
+++ b/assets/vue/components/BlockedIncident.vue
@@ -97,11 +97,11 @@ export default {
     var(--bs-warning-bg-subtle) 10px,
     var(--bs-warning-bg-subtle) 20px
   );
-  td {
-    background-color: initial;
-  }
-  td:nth-child(1) a {
-    font-weight: bold;
-  }
+}
+.high-priority td {
+  background-color: initial;
+}
+.high-priority td:nth-child(1) a {
+  font-weight: bold;
 }
 </style>


### PR DESCRIPTION
Older browsers like a current Firefox ESR 115 do not yet understand
nested CSS instructions so without significant duplication we can just
define rules which support older browsers as well.

Verified manually by running qem-dashboard within a Tumbleweed container
where I manually installed all dependencies and then run the dashboard
app within the container with the port forwarded to my local development
where I could access the served pages with Firefox ESR.

Related progress issue: https://progress.opensuse.org/issues/163586