### PR TITLE
Consider "acceptable for" comments/remarks on blocked page

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -584,3 +584,60 @@ None
   ...
 ]
 ```
+
+#### Remarks on openQA jobs
+`GET /api/jobs/<job_id>/remarks`
+
+List remarks on an openQA job.
+
+**Request parameters:**
+
+None
+
+**Request body:**
+
+None
+
+**Response:**
+
+```
+{
+  "remarks": [
+    {
+      "text": "foo",
+      "incident": 1234
+    },
+    {
+      "text": "bar",
+      "incident": 5678
+    }
+    ...
+  ]
+}
+```
+
+---
+
+`PATCH /api/jobs/<job_id>/remarks`
+
+Creates or updates a remark on an openQA job, possibly incident-specific.
+
+Only one remark can exist per incident.
+
+**Request parameters:**
+
+* `incident_number` (optional): The incident number if the remark is incident-specific.
+
+* `text` (optional): The remark text, defaults to an empty text.
+
+**Request body:**
+
+None
+
+**Response:**
+
+```
+{
+  "message": "Ok"
+}
+```

--- a/lib/Dashboard.pm
+++ b/lib/Dashboard.pm
@@ -131,6 +131,8 @@ sub startup ($self) {
   $api->put('/update_settings')->to('API::Settings#add_update_settings');
   $api->get('/jobs/<job_id:num>')->to('API::Jobs#show');
   $api->patch('/jobs/<job_id:num>')->to('API::Jobs#modify');
+  $api->get('/jobs/<job_id:num>/remarks')->to('API::Jobs#show_remarks');
+  $api->patch('/jobs/<job_id:num>/remarks')->to('API::Jobs#update_remark');
   $api->put('/jobs')->to('API::Jobs#add');
   $api->get('/jobs/incident/<incident_settings:num>')->to('API::Jobs#incidents');
   $api->get('/jobs/update/<update_settings:num>')->to('API::Jobs#updates');

--- a/lib/Dashboard/Model/Incidents.pm
+++ b/lib/Dashboard/Model/Incidents.pm
@@ -95,6 +95,11 @@ sub incident_for_number ($self, $number) {
   return $self->pg->db->query('select * from incidents where number = ? limit 1', $number)->hash;
 }
 
+sub number_for_id ($self, $id) {
+  return undef unless my $array = $self->pg->db->query('select number from incidents where id = ? limit 1', $id)->array;
+  return $array->[0];
+}
+
 sub id_for_number ($self, $number) {
   return undef
     unless my $array = $self->pg->db->query('select id from incidents where number = ? limit 1', $number)->array;

--- a/lib/Dashboard/Model/Jobs.pm
+++ b/lib/Dashboard/Model/Jobs.pm
@@ -28,7 +28,16 @@ sub add ($self, $job) {
      RETURNING id', $job->{incident_settings}, $job->{update_settings}, $job->{name}, $job->{job_group},
     $job->{job_id}, $job->{group_id}, $job->{status}, $job->{distri}, $job->{flavor}, $job->{version}, $job->{arch},
     $job->{build}
-  );
+  )->array->[0];
+}
+
+sub add_remark ($self, $openqa_job_id, $incident_id, $text) {
+  $self->pg->db->query(
+    'INSERT INTO job_remarks (openqa_job_id, incident_id, text) VALUES (?, ?, ?)
+     ON CONFLICT (openqa_job_id, incident_id)
+     DO UPDATE SET text = EXCLUDED.text
+     RETURNING id',
+    $openqa_job_id, $incident_id, $text)->array->[0];
 }
 
 # Disabled to test without cleanup in production

--- a/migrations/dashboard.sql
+++ b/migrations/dashboard.sql
@@ -108,3 +108,12 @@ ALTER TABLE incidents ADD COLUMN embargoed BOOLEAN DEFAULT FALSE;
 
 --7 up
 ALTER TABLE incidents ADD COLUMN priority INTEGER;
+
+--8 up
+CREATE TABLE IF NOT EXISTS job_remarks (
+  id            SERIAL PRIMARY KEY,
+  openqa_job_id INT NOT NULL REFERENCES openqa_jobs(id) ON DELETE CASCADE,
+  incident_id   INT REFERENCES incidents(id) ON DELETE CASCADE,
+  text          TEXT NOT NULL
+);
+CREATE UNIQUE INDEX ON job_remarks(openqa_job_id, incident_id);

--- a/t/amqp.t
+++ b/t/amqp.t
@@ -29,18 +29,19 @@ my $dashboard_test = Dashboard::Test->new(online => $ENV{TEST_ONLINE}, schema =>
 my $config         = $dashboard_test->default_config;
 my $t              = Test::Mojo->new(Dashboard => $config);
 $dashboard_test->minimal_fixtures($t->app);
-my $db = $t->app->pg->db;
+my $db     = $t->app->pg->db;
+my $job_id = 11;
 
 sub _is_field ($field, $expected) {
-  is($db->query("SELECT $field FROM openqa_jobs WHERE id = 9")->hash->{$field}, $expected);
+  is($db->query("SELECT $field FROM openqa_jobs WHERE id = $job_id")->hash->{$field}, $expected);
 }
 
 sub _is_count ($expected) {
-  is($db->query("SELECT COUNT(*) FROM openqa_jobs WHERE id = 9")->hash->{count}, $expected);
+  is($db->query("SELECT COUNT(*) FROM openqa_jobs WHERE id = $job_id")->hash->{count}, $expected);
 }
 
 sub _set_default() {
-  $db->query("UPDATE openqa_jobs SET status = 'waiting', job_id = 4953203 WHERE id = 9");
+  $db->query("UPDATE openqa_jobs SET status = 'waiting', job_id = 4953203 WHERE id = $job_id");
 }
 
 subtest 'Handle done job' => sub {

--- a/t/api.t
+++ b/t/api.t
@@ -32,8 +32,8 @@ $dashboard_test->no_fixtures($t->app);
 my $auth_headers = {Authorization => 'Token test_token', Accept => 'application/json'};
 
 subtest 'Migrations' => sub {
-  is $t->app->pg->migrations->latest, 7, 'latest version';
-  is $t->app->pg->migrations->active, 7, 'active version';
+  is $t->app->pg->migrations->latest, 8, 'latest version';
+  is $t->app->pg->migrations->active, 8, 'active version';
 };
 
 subtest 'Unknown endpoint' => sub {

--- a/t/json.t
+++ b/t/json.t
@@ -150,6 +150,17 @@ subtest 'Blocked by Tests' => sub {
             },
             "name"    => "SLE 12 SP5",
             "waiting" => 1
+          },
+          "55 Server-DVD-Incidents 12-SP6" => {
+            "linkinfo" => {
+              "build"   => "20250317-1",
+              "distri"  => "sle",
+              "flavor"  => "Server-DVD-Incidents",
+              "groupid" => 55,
+              "version" => "12-SP6"
+            },
+            "name"   => "Server-DVD-Incidents 12-SP6",
+            "passed" => 2
           }
         }
       },
@@ -192,6 +203,18 @@ subtest 'Blocked by Tests' => sub {
             },
             "name"   => "SAP/HA Maintenance",
             "passed" => 2
+          },
+          "55 Server-DVD-Incidents 12-SP6" => {
+            "linkinfo" => {
+              "build"   => "20250317-1",
+              "distri"  => "sle",
+              "flavor"  => "Server-DVD-Incidents",
+              "groupid" => 55,
+              "version" => "12-SP6"
+            },
+            "name"   => "Server-DVD-Incidents 12-SP6",
+            "passed" => 1,
+            "failed" => 1
           }
         }
       }
@@ -272,6 +295,32 @@ subtest 'Incident Details' => sub {
     )
     ->json_is(
     '/details/jobs' => {
+      "20250317-1" => [
+        {
+          "arch"      => "x86_64",
+          "build"     => "20250317-1",
+          "distri"    => "sle",
+          "flavor"    => "Server-DVD-Incidents",
+          "group_id"  => 55,
+          "job_group" => "Server-DVD-Incidents 12-SP6",
+          "job_id"    => 4953600,
+          "name"      => "acceptable_for_16860_despite_failing\@64bit",
+          "status"    => "failed",
+          "version"   => "12-SP6"
+        },
+        {
+          "arch"      => "x86_64",
+          "build"     => "20250317-1",
+          "distri"    => "sle",
+          "flavor"    => "Server-DVD-Incidents",
+          "group_id"  => 55,
+          "job_group" => "Server-DVD-Incidents 12-SP6",
+          "job_id"    => 4953601,
+          "name"      => "acceptable_for_16860_but_passing_anyway\@64bit",
+          "status"    => "passed",
+          "version"   => "12-SP6"
+        }
+      ],
       "20201107-1" => [
         {
           "arch"      => "x86_64",

--- a/t/lib/Dashboard/Test.pm
+++ b/t/lib/Dashboard/Test.pm
@@ -346,6 +346,55 @@ sub minimal_fixtures ($self, $app) {
     }
   );
 
+  # Add failing build that is acceptable for a certain incident
+  my @incident_numbers           = (16860, 29722);
+  my @incident_ids               = map { $incidents->id_for_number($_) } @incident_numbers;
+  my $settings_acceptable_for_id = $settings->add_update_settings(
+    \@incident_ids,
+    {
+      incidents => \@incident_numbers,
+      product   => 'SLES-12-SP6',
+      arch      => 'x86_64',
+      build     => '20250317-1',
+      repohash  => 'd5815a9f8aa482ec8288508da27a9d37',
+      settings  =>
+        {DISTRI => 'sle', VERSION => '12-SP6', BUILD => '20201108-1', REPOHASH => 'd5815a9f8aa482ec8288508da27a9d37'}
+    }
+  );
+  my $acceptable_for_16860_job_1_id = $jobs->add(
+    {
+      incident_settings => undef,
+      update_settings   => $settings_acceptable_for_id,
+      name              => 'acceptable_for_16860_despite_failing@64bit',
+      job_group         => 'Server-DVD-Incidents 12-SP6',
+      status            => 'failed',
+      job_id            => 4953600,
+      group_id          => 55,
+      distri            => 'sle',
+      flavor            => 'Server-DVD-Incidents',
+      arch              => 'x86_64',
+      version           => '12-SP6',
+      build             => '20250317-1'
+    }
+  );
+  my $acceptable_for_16860_job_2_id = $jobs->add(
+    {
+      incident_settings => undef,
+      update_settings   => $settings_acceptable_for_id,
+      name              => 'acceptable_for_16860_but_passing_anyway@64bit',
+      job_group         => 'Server-DVD-Incidents 12-SP6',
+      status            => 'passed',
+      job_id            => 4953601,
+      group_id          => 55,
+      distri            => 'sle',
+      flavor            => 'Server-DVD-Incidents',
+      arch              => 'x86_64',
+      version           => '12-SP6',
+      build             => '20250317-1'
+    }
+  );
+  $jobs->add_remark($acceptable_for_16860_job_1_id, $incident_ids[0], 'acceptable_for');
+
   # Waiting build
   my $settings_waiting_id = $settings->add_update_settings(
     [map { $incidents->id_for_number($_) } 16860, 16861],


### PR DESCRIPTION
* Add a table to store "remarks" specific to job/incident combinations
* Consider a job (in the context of a specific incident) always passing when an "acceptable for" remark for this job/incident combination exists
* See https://progress.opensuse.org/issues/161267