### PR TITLE
Consider "acceptable for" comments/remarks for incident jobs as well

### DIFF
--- a/t/api_cleanup.t
+++ b/t/api_cleanup.t
@@ -111,7 +111,7 @@ subtest 'Clean up jobs after rr_number change (during sync)' => sub {
     ->json_has('/details/jobs/20201107-1')
     ->json_has('/details/jobs/20201107-2')
     ->json_has('/details/jobs/20201108-1')
-    ->json_is('/details/incident_summary', {passed => 1, failed => 1, waiting => 1});
+    ->json_is('/details/incident_summary', {passed => 2, failed => 2, waiting => 1});
   $t->get_ok('/app/api/incident/16861')
     ->status_is(200)
     ->json_is('/details/incident/number',   16861)
@@ -160,7 +160,7 @@ subtest 'Clean up jobs after rr_number change (during sync)' => sub {
     ->json_has('/details/jobs/20201107-1')
     ->json_has('/details/jobs/20201107-2')
     ->json_has('/details/jobs/20201108-1')
-    ->json_is('/details/incident_summary', {passed => 1, failed => 1, waiting => 1});
+    ->json_is('/details/incident_summary', {passed => 2, failed => 2, waiting => 1});
   $t->get_ok('/app/api/incident/16861')
     ->status_is(200)
     ->json_is('/details/incident/number',   16861)

--- a/t/json.t
+++ b/t/json.t
@@ -123,6 +123,11 @@ subtest 'Blocked by Tests' => sub {
           "rr_number"  => 230066
         },
         "incident_results" => {
+          "55" => {
+            "name"     => 'Server-DVD-Incidents 12-SP6',
+            "linkinfo" => {"build" => "20250317-1", "distri" => "sle", "groupid" => 55},
+            "passed"   => 2
+          },
           "282" => {
             "linkinfo" => {"build" => ":17063:perl-Mojolicious", "distri" => "sle", "groupid" => 282},
             "name"     => "SLE 12 SP5",
@@ -377,9 +382,8 @@ subtest 'Incident Details' => sub {
       ]
     }
     )
-    ->json_is('/details/incident_summary' => {waiting => 1, failed => 1, passed => 1})
-    ->json_is('/details/build_nr'         => ':17063:perl-Mojolicious');
-
+    ->json_is('/details/incident_summary' => {waiting => 1, failed => 2, passed => 2})
+    ->json_is('/details/build_nr'         => '20250317-1');
 };
 
 done_testing();

--- a/t/lib/Dashboard/Test.pm
+++ b/t/lib/Dashboard/Test.pm
@@ -21,6 +21,8 @@ use Mojo::Pg;
 use Mojo::URL;
 use Mojo::Util qw(scope_guard);
 
+has options => undef;
+
 sub new ($class, %options) {
 
   # Database
@@ -347,9 +349,20 @@ sub minimal_fixtures ($self, $app) {
   );
 
   # Add failing build that is acceptable for a certain incident
-  my @incident_numbers           = (16860, 29722);
-  my @incident_ids               = map { $incidents->id_for_number($_) } @incident_numbers;
-  my $settings_acceptable_for_id = $settings->add_update_settings(
+  my @incident_numbers             = (16860, 29722);
+  my @incident_ids                 = map { $incidents->id_for_number($_) } @incident_numbers;
+  my $settings_acceptable_for_id_1 = $settings->add_incident_settings(
+    $incident_ids[0],
+    {
+      incident      => $incident_ids[0],
+      version       => '12-SP6',
+      flavor        => 'Server-DVD-Incidents',
+      arch          => 'x86_64',
+      withAggregate => true,
+      settings      => {DISTRI => 'sle', VERSION => '12-SP6', BUILD => '20250317-1'}
+    }
+  ) unless $self->options->{schema} eq 'js_ui_test';
+  my $settings_acceptable_for_id_2 = $settings->add_update_settings(
     \@incident_ids,
     {
       incidents => \@incident_numbers,
@@ -363,8 +376,8 @@ sub minimal_fixtures ($self, $app) {
   );
   my $acceptable_for_16860_job_1_id = $jobs->add(
     {
-      incident_settings => undef,
-      update_settings   => $settings_acceptable_for_id,
+      incident_settings => $settings_acceptable_for_id_1,
+      update_settings   => $settings_acceptable_for_id_2,
       name              => 'acceptable_for_16860_despite_failing@64bit',
       job_group         => 'Server-DVD-Incidents 12-SP6',
       status            => 'failed',
@@ -379,8 +392,8 @@ sub minimal_fixtures ($self, $app) {
   );
   my $acceptable_for_16860_job_2_id = $jobs->add(
     {
-      incident_settings => undef,
-      update_settings   => $settings_acceptable_for_id,
+      incident_settings => $settings_acceptable_for_id_1,
+      update_settings   => $settings_acceptable_for_id_2,
       name              => 'acceptable_for_16860_but_passing_anyway@64bit',
       job_group         => 'Server-DVD-Incidents 12-SP6',
       status            => 'passed',


### PR DESCRIPTION
* Apply what was introduced for update openQA jobs in c459554a0 to incident openQA jobs as well
* See https://progress.opensuse.org/issues/161267

---

After noticing that c459554a0 doesn't work in production (see https://progress.opensuse.org/issues/161267#note-27) I created a database dump of the production data and imported it locally. So I can say that this works now with production data from yesterday.