### PR TITLE
Add container definition and quadlets

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,9 @@
+*.md
+assets/assetpack.db
+assets/cache
+public/asset
+node_modules
+cover_db/
+containers
+.git
+.github

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,25 @@
+FROM opensuse/tumbleweed:latest
+
+# Install dependencies
+RUN zypper in -y -C \
+    perl-Mojolicious \
+    perl-Mojolicious-Plugin-Webpack \
+    perl-Mojo-Pg \
+    perl-Cpanel-JSON-XS \
+    perl-JSON-Validator \
+    perl-IO-Socket-SSL \
+    nodejs-default \
+    npm
+
+# Install application
+WORKDIR /app
+COPY . .
+# Alternatively, use sources from git (also needs git added to dependencies)
+# RUN git clone https://github.com/openSUSE/qem-dashboard .
+
+# Install node dependencies
+RUN npm install
+RUN npx playwright install
+
+EXPOSE 3000
+ENTRYPOINT ["mojo", "webpack", "script/dashboard"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install all required dependencies, run
       perl-Mojo-Pg perl-Cpanel-JSON-XS perl-JSON-Validator perl-IO-Socket-SSL nodejs-default npm
     npm install
 
-if you are on an apt-based system, run 
+if you are on an apt-based system, run
 
     npx playwright install --with-deps
 
@@ -104,7 +104,8 @@ For further documentation, please see **[docs](https://github.com/openSUSE/qem-d
 ### Further notes
 A containerized environment could be used to build and run the dashboard and its dependencies.
 For a concrete example, checkout the (so far) internal documentation under
-https://gitlab.suse.de/qe-core/dev-dashboard.
+https://gitlab.suse.de/qe-core/dev-dashboard or containers quick start guide
+in **[docs/Containers](https://github.com/openSUSE/qem-dashboard/tree/main/docs/Containers.md)**
 
 ## License
 

--- a/containers/systemd/postgres.container
+++ b/containers/systemd/postgres.container
@@ -1,0 +1,6 @@
+[Container]
+Environment=POSTGRES_HOST_AUTH_METHOD=trust
+Pod=qem.pod
+Image=registry.opensuse.org/opensuse/postgres:latest
+AutoUpdate=registry
+Mount=type=bind,source=/var/lib/data/qem/psql-data,destination=/var/lib/pgsql/data,relabel=private

--- a/containers/systemd/qem-dashboard.build
+++ b/containers/systemd/qem-dashboard.build
@@ -1,0 +1,4 @@
+[Build]
+ImageTag=localhost/qem-dashboard
+SetWorkingDirectory=file
+File=/var/lib/data/qem/qem-dashboard/Containerfile

--- a/containers/systemd/qem-dashboard.container
+++ b/containers/systemd/qem-dashboard.container
@@ -1,0 +1,3 @@
+[Container]
+Pod=qem.pod
+Image=qem-dashboard.build

--- a/containers/systemd/qem.pod
+++ b/containers/systemd/qem.pod
@@ -1,0 +1,2 @@
+[Pod]
+PublishPort=3000:3000

--- a/docs/Containers.md
+++ b/docs/Containers.md
@@ -1,0 +1,11 @@
+# Deploying qem-dashboard inside containers on MicroOS
+
+## A quick start guide
+
+1. `mkdir -p /var/lib/data/qem/psql-data && cd /var/lib/data/qem`
+2. `git clone https://github.com/openSUSE/qem-dashboard.git`
+3. `sed -i -e 's#pg: .*#pg: postgresql://postgres@localhost:5432/postgres#' qem-dashboard/dashboard.yml`
+4. `for quadlet in qem-dashboard/containers/systemd/*; do ln -s "$PWD/$quadlet" /etc/containers/systemd/; done`
+5. `systemctl daemon-reload && systemctl start qem-pod`
+
+After `podman build` completes, new container is spawned inside the pod and the qem-dashboard will be available on port 3000.

--- a/docs/Folders.md
+++ b/docs/Folders.md
@@ -1,5 +1,6 @@
 - **[assets](/assets)**: Contains JavaScript files, stylesheets, etc.
 - **[cpanfile](/cpanfile)**: Configuration file used to manage Perl dependencies.
+- **[containers](/containers)**: Contains quadlet definitions for Podman
 - **[docs](/docs)**: Project documentation.
 - **[eslint.config.mjs](/eslint.config.mjs)**: Configuration file for JavaScript linter.
 - **[lib](/lib)**: Core library of Perl code.
@@ -24,4 +25,3 @@
 - **[t](/t)**: Containing test files.
 - **[templates](/templates)**: Template files, used to generate dynamic content.
 - **[webpack.config.js](/webpack.config.js)**: Configuration file for Webpack, a JavaScript bundler used to prepare code for production.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,7 @@ Reference documentation for the QEM-Dashboard REST API
 * [Folders](Folders.md)
 
 Information about the project directory structure
+
+* [Containers](Containers.md)
+
+Information how to deploy the project inside containers with Podman and quadlets


### PR DESCRIPTION
Describe how to deploy containerized qem-dashboard with quadlets and Podman on something like MicroOS. This solution is bundled with an own database container and is suitable for testing or small production deployments.