### PR TITLE
Bump @babel/plugin-transform-regenerator from 7.27.0 to 7.27.1 and fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "moment": "^2.30.1",
         "playwright": "^1.52.0",
         "prettier": "^3.5.3",
+        "regenerator-transform": "^0.15.2",
         "sass": "^1.89.0",
         "sass-loader": "^16.0.5",
         "tap": "^21.1.0",
@@ -1445,6 +1446,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
+      "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -8692,6 +8701,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/regenerator-transform": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -11648,6 +11665,11 @@
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
       }
+    },
+    "@babel/runtime": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
+      "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw=="
     },
     "@babel/template": {
       "version": "7.27.2",
@@ -16262,6 +16284,14 @@
       "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
       "requires": {
         "regenerate": "^1.4.2"
+      }
+    },
+    "regenerator-transform": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+      "requires": {
+        "@babel/runtime": "^7.8.4"
       }
     },
     "regexpp": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "vue-router": "^4.5.1",
     "vue-template-compiler": "^2.7.16",
     "webpack": "^5.99.9",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "regenerator-transform": "^0.15.2"
   }
 }


### PR DESCRIPTION
I found out that if I explicitly add `regenerator-transform` in `package.json`, the test does not fail anymore in CI.

I could still not reproduce the failure locally (I did remove the node_modules directory and ran `npm install` when switching between commits).

The error message was `Unknown asset name "qem-dashboard.js".` and I found out that webpack.pm did not generate any assets in the failing case, so I thought `regenerator-transform` and generating assets could be related...

Issue: https://progress.opensuse.org/issues/182747