### PR TITLE
Show Gitea-based incidents on blocked page

### DIFF
--- a/lib/Dashboard/Model/Incidents.pm
+++ b/lib/Dashboard/Model/Incidents.pm
@@ -20,9 +20,9 @@ has [qw(log pg)];
 
 sub blocked ($self) {
   my $incidents = $self->pg->db->query(
-    'SELECT * FROM incidents
-     WHERE active = TRUE AND approved = FALSE AND review_qam = TRUE AND rr_number IS NOT NULL
-     ORDER BY number'
+    "SELECT * FROM incidents
+     WHERE active = TRUE AND approved = FALSE AND review_qam = TRUE AND (rr_number IS NOT NULL OR type = 'git')
+     ORDER BY number"
   )->hashes->to_array;
   return [
     map {


### PR DESCRIPTION
Gitea-based incidents don't have an `rr_number` and probably also won't get one. So we should display them regardless of the presence of that number.

Related ticket: https://progress.opensuse.org/issues/180812

---

Tested manually:

![screenshot_20250528_111656](https://github.com/user-attachments/assets/039a912b-1454-4499-beb7-ca7b13d3378d)
