### PR TITLE
Allow syncing incidents by type

### DIFF
--- a/lib/Dashboard/Controller/API/Incidents.pm
+++ b/lib/Dashboard/Controller/API/Incidents.pm
@@ -51,7 +51,7 @@ sub sync ($self) {
   my @errors = $jv->validate($incidents);
   return $self->render(json => {error => "Incidents do not match the JSON schema: @errors"}, status => 400) if @errors;
 
-  $self->incidents->sync($incidents);
+  $self->incidents->sync($incidents, $self->every_param('type'));
 
   # Disabled to test without cleanup in production
   #$self->jobs->cleanup_aggregates;

--- a/lib/Dashboard/Model/Incidents.pm
+++ b/lib/Dashboard/Model/Incidents.pm
@@ -164,11 +164,12 @@ sub repos ($self) {
   return \%titles;
 }
 
-sub sync ($self, $incidents) {
+sub sync ($self, $incidents, $types = []) {
+  push @$types, '', 'smelt' unless @$types;
   my $db = $self->pg->db;
   my $tx = $db->begin;
 
-  $db->query('UPDATE incidents SET active = FALSE');
+  $db->update(incidents => {active => 0}, {type => {'=' => $types}});
   for my $incident (@$incidents) { $self->_update($db, $incident) }
 
   $tx->commit;


### PR DESCRIPTION
When syncing incidents all existing incidents are considered inactive. We now want to sync incidents of different types. To avoid considering all incidents from SMELT inactive when syncing incidents from Gitea this change introduces an additional type parameter so only incidents of the specified type are considered inactive. For backwards compatibility no type means SMELT.

Related ticket: https://progress.opensuse.org/issues/180812