### PR TITLE
mergify: Only use fast-forward merges for expected, trusted deployments

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,7 @@ pull_request_rules:
         - "#review-requested=0"
     actions: &merge
       merge:
-        method: merge
+        method: fast-forward
   - name: automatic merge on special label
     conditions:
       - and: *base_checks


### PR DESCRIPTION
Same as
https://github.com/openSUSE/qem-bot/pull/209
but for qem-dashboard.

As we deploy only from verified and SUSE trusted git commits excluding
mergify merge requests doing most of the merging of pull requests we can
at least configure mergify to do only fast-forward merges so that (in my
understanding) mergify will only merge pull requests that are rebased on
the main branch. By this we last commit of each pull request is a
candidate for deployment rather than undefined/unexpected behaviour in
case of a pull request with non-rebased branch being merged.

The mergify documentation is not entirely clear to me but based on
https://blog.mergify.com/whats-the-best-git-merge-strategy/ and
https://docs.mergify.com/workflow/actions/merge/ I assume that mergify
will not automatically merge non-rebased branches.  On github I have
enabled the option "Always suggest updating pull request branches" so
maybe the feedback for reviewers and reviewees should be clear enough
why a non-rebased branch is not automatically merged yet.