### PR TITLE
CI: Try to fix dependabot merges with auto-rebase

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,6 +34,7 @@ pull_request_rules:
         - author=dependabot[bot]
         - "label=waited"
     actions:
+      rebase:
       merge:
         method: squash
   - name: ask to resolve conflict


### PR DESCRIPTION
Since we have changed the github repository settings to only allow up-to-date branches to be merged we should ask mergify to automatically rebase "waited" dependabot pull requests. I actually don't know if the double action definition "rebase" and "merge" will work. We have to try this with the mergify rules just being active in production.