### PR TITLE
replace axios with fetch

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3,7 +3,6 @@ import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.css';
 import router from './router.js';
 import App from './vue/App.vue';
-import axios from 'axios';
 import {createApp} from 'vue';
 
 const backToTop = function () {
@@ -31,13 +30,10 @@ const backToTop = function () {
   mybutton.addEventListener('click', scrollUp);
 };
 
-window.addEventListener('load', () => {
-  axios('/app-config').then(response => {
-    const config = response.data;
-    const app = createApp(App);
-    app.config.globalProperties.appConfig = config;
-    app.use(router).mount('#app');
-
-    backToTop();
-  });
+window.addEventListener('load', async () => {
+  const config = await fetch('/app-config').then(res => res.json());
+  const app = createApp(App);
+  app.config.globalProperties.appConfig = config;
+  app.use(router).mount('#app');
+  backToTop();
 });

--- a/assets/vue/mixins/refresh.js
+++ b/assets/vue/mixins/refresh.js
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 export default {
   data() {
     return {
@@ -15,12 +13,10 @@ export default {
     this.cancelApiRefresh();
   },
   methods: {
-    doApiRefresh() {
-      axios.get(this.refreshUrl).then(response => {
-        const {data} = response;
-        this.$emit('last-updated', data.last_updated);
-        this.refreshData(data);
-      });
+    async doApiRefresh() {
+      const data = await fetch(this.refreshUrl).then(res => res.json());
+      this.$emit('last-updated', data.last_updated);
+      this.refreshData(data);
     },
     cancelApiRefresh() {
       clearInterval(this.refreshTimer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@mojojs/core": "^1.26.10",
         "@mojojs/path": "^1.7.0",
         "@mojolicious/server-starter": "^2.2.0",
-        "axios": "^1.12.1",
         "babel-loader": "^10.0.0",
         "bootstrap": "^5.3.7",
         "copy-webpack-plugin": "^13.0.1",
@@ -3940,16 +3939,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/axios": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
-      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/babel-loader": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
@@ -5746,25 +5735,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -8454,11 +8424,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -13147,16 +13112,6 @@
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
     },
-    "axios": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
-      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
-      "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "babel-loader": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
@@ -14287,11 +14242,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="
-    },
-    "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
     },
     "foreground-child": {
       "version": "3.3.1",
@@ -16043,11 +15993,6 @@
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@mojojs/core": "^1.26.10",
     "@mojojs/path": "^1.7.0",
     "@mojolicious/server-starter": "^2.2.0",
-    "axios": "^1.12.1",
     "babel-loader": "^10.0.0",
     "bootstrap": "^5.3.7",
     "copy-webpack-plugin": "^13.0.1",


### PR DESCRIPTION
`fetch`  is built in to node since `18`:

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility

<img width="1204" height="398" alt="image" src="https://github.com/user-attachments/assets/36b88bc9-8bdc-4bec-aba7-a7593c8fe77d" />

Replacing `axios` with fetch saves on the bundle size and lightens the supply chain surface.