### PR TITLE
Enable automatic dependabot updates again after upstream improved

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
         - "#check-failure=0"
         - "#check-pending=0"
         - linear-history
-      - and: &manual_review
+      - and:
         - "#approved-reviews-by>=2"
         - "#changes-requested-reviews-by=0"
         # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
@@ -33,7 +33,6 @@ pull_request_rules:
         - base=main
         - author=dependabot[bot]
         - "label=waited"
-      - and: *manual_review
     actions:
       rebase:
       merge:


### PR DESCRIPTION
This reverts commit 68706bee0b6288a635727860d4c3457f4d666f43.

To me it seems the situation has cooled down. We have reviewed practices for
handling updates. In my understanding our previous approach of automated but
slightly delayed updates is still fine.

Related progress issue: https://progress.opensuse.org/issues/189195