### PR TITLE
CI: Remove erroneous 'autoqueue'

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ merge_queue:
 queue_rules:
   - name: default
     batch_size: 1
-    autoqueue: true
 
 pull_request_rules:
   - name: automatic merge


### PR DESCRIPTION
We do not want to have all PRs merged automatically, only the 'waited'
ones.