### PR TITLE
Remove (likely) never called "name" method

### DIFF
--- a/lib/Dashboard/Model/Incidents.pm
+++ b/lib/Dashboard/Model/Incidents.pm
@@ -107,13 +107,6 @@ sub id_for_number ($self, $number) {
   return $array->[0];
 }
 
-sub name ($self, $inc) {
-  return "$inc->{number}:unknown"
-    unless my $hash
-    = $self->pg->db->query('SELECT packages[1] as package FROM incidents WHERE number = ?', $inc->{number})->hash;
-  return "$inc->{number}:$hash->{package}";
-}
-
 sub repos ($self) {
   my %titles;
   my $db  = $self->pg->db;

--- a/lib/Dashboard/Model/Jobs.pm
+++ b/lib/Dashboard/Model/Jobs.pm
@@ -142,7 +142,7 @@ sub _normalize_result ($result) {
   return 'stopped'
     if grep { $result eq $_ }
     qw(timeout_exceeded incomplete obsoleted parallel_failed skipped parallel_restarted user_cancelled user_restarted);
-  return 'failed';  # uncoverable statement
+  return 'failed';    # uncoverable statement
 }
 
 1;


### PR DESCRIPTION
The method "name" shows up as uncovered in the coverage report so I
assume it's actually unused.