### PR TITLE
Avoid installing random npm packages via `mojo webpack … script/dashboard`

### DIFF
--- a/lib/Dashboard.pm
+++ b/lib/Dashboard.pm
@@ -17,10 +17,14 @@ package Dashboard;
 use Mojo::Base 'Mojolicious', -signatures;
 
 use Mojo::Pg;
+use Mojo::File qw(curfile);
 use Dashboard::Model::Incidents;
 use Dashboard::Model::Jobs;
 use Dashboard::Model::Settings;
 use Dashboard::Model::AMQP;
+
+# Avoid installing random npm packages bypassing package-lock.json
+BEGIN { $ENV{MOJO_NPM_BINARY} = curfile->sibling('../script/npm-noop') }
 
 # This method will run once at server start
 sub startup ($self) {

--- a/script/npm-noop
+++ b/script/npm-noop
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+if [[ $1 == ls ]]; then
+  exec npm "$@"
+fi


### PR DESCRIPTION
It seems like `Mojo::Alien::webpack` can install additional packages that are not mentioned in `package-lock.json` or `packages.json`. This leads to both files being modified, see https://progress.opensuse.org/issues/191193.

Besides the failing pipeline, this brings the much bigger problem that the list of npm packages and their concrete versions are effectively bypassed so problematic packages might be used without us knowing which is of course a big security risk.

This change fixes that by simply making the `npm` command a noop (except for `npm ls` which is required by `Mojo::Alien::webpack`).

Related ticket: https://progress.opensuse.org/issues/191193