### PR TITLE
Avoid implicit and possibly insecure asset processing within web service

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,9 +17,10 @@ COPY . .
 # Alternatively, use sources from git (also needs git added to dependencies)
 # RUN git clone https://github.com/openSUSE/qem-dashboard .
 
-# Install node dependencies
-RUN npm install --ignore-scripts
-RUN npx playwright install
+# Install node dependencies and bundle assets
+RUN npm install --ignore-scripts && \
+    npm run build && \
+    npx playwright install
 
 EXPOSE 3000
-ENTRYPOINT ["mojo", "webpack", "script/dashboard"]
+ENTRYPOINT ["script/dashboard", "daemon"]

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ install-deps-cpanm:
 .PHONY: install-deps
 install-deps: install-deps-js install-deps-ubuntu install-deps-cpanm
 
+.PHONY: build
+build:
+	npm run build
+
 .PHONY: start-postgres
 start-postgres:
 	podman run -p 5432:5432 -e POSTGRES_PASSWORD=postgres -d docker.io/library/postgres

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ Make sure the config file `dashboard.yml` points to your PostgreSQL database (an
     smelt:
       url: https://smelt.suse.de
 
-And finally use the `mojo webpack` development web server to make the web application available under
+Call `npm run build` to bundle assets.
+
+And finally use the `script/dashboard daemon` development web server to make the web application available under
 `http://127.0.0.1:3000`.
 
-    $ mojo webpack script/dashboard
+    $ script/dashboard daemon
     Web application available at http://127.0.0.1:3000
 
 ## Contribute

--- a/lib/Dashboard.pm
+++ b/lib/Dashboard.pm
@@ -66,7 +66,7 @@ sub startup ($self) {
 
   $self->plugin('Dashboard::Plugin::JSON');
   $self->plugin('Dashboard::Plugin::Helpers');
-  $self->plugin(Webpack => {process => [qw(js css sass vue)]});
+  $self->plugin('Webpack', {process => []});    # pass empty array as Webpack defaults to processing JS files
 
   # Compress dynamically generated content
   $self->renderer->compress(1);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "lib": "lib"
   },
   "scripts": {
+    "build": "npx webpack",
+    "build:clean": "npm run clean && npm run build",
+    "clean": "rm -r public/asset/*",
     "lint": "eslint \"assets/*.js\" \"assets/**/*.js\" \"assets/**/*.vue\" \"t/*.js\" --ignore-pattern assets/webpack.config.d",
     "lint:fix": "npm run lint -- --fix"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,10 +9,11 @@ import webpack from 'webpack';
 const assetsDir = process.env.WEBPACK_ASSETS_DIR || Path.currentFile().sibling('assets').toString();
 const isDev = process.env.NODE_ENV !== 'production';
 
-const output = {};
-output.filename = isDev ? '[name].development.js' : '[name].[chunkhash].js';
-output.path = process.env.WEBPACK_OUT_DIR || Path.currentFile().sibling('dist').toString();
-output.publicPath = '';
+const output = {
+  filename: isDev ? '[name].development.js' : '[name].[chunkhash].js',
+  path: process.env.WEBPACK_OUT_DIR || Path.currentFile().sibling('public', 'asset').toString(),
+  publicPath: ''
+};
 
 const entry = new Path(assetsDir, 'main.js').toString();
 


### PR DESCRIPTION
* Remove the `process` argument when loading the Webpack plugin like in Cavil
* Run `npx webpack` via `npm run build` like in Cavil and add a Makefile target like we have for other `npm` commands that need to be executed
* Adjust `webpack.config.js` to use an output path that is in-line with Cavil
* Remove `mojo webpack …` commands from README as starting the web application with these commands can lead to unwanted `npm` invocations
* Avoid `mojo webpack …` in container file as well

Note that one *can* still execute `mojo webpack …`. This would also install npm packages unasked and without `--ignore-scripts` as we recommend in the README. Hence it makes perhaps still sense to keep the previous change that makes npm commands executed via `mojo webpack script/dashboard` a no-op.

Related ticket: https://progress.opensuse.org/issues/191193