### PR TITLE
Disable eslint workflow

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,6 +4,8 @@ name: eslint
 on: [push, pull_request]
 jobs:
   test:
+    if: false  # disabled because currently failing
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v6


### PR DESCRIPTION
The workflow file was broken in deea3dd67302ac74687fb5b33c6b0c8cff957548
but the check disappeared from PRs so noone was aware.
But we are now getting emails about every broken workflow run, so disabling
is better if the fix is not trivial.
    
See https://progress.opensuse.org/issues/180872 for the related ticket
