### PR TITLE
Make new `npm run clean` command also work if already clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "npx webpack",
     "build:clean": "npm run clean && npm run build",
-    "clean": "rm -r public/asset/*",
+    "clean": "rm -fr public/asset/*",
     "lint": "eslint \"assets/*.js\" \"assets/**/*.js\" \"assets/**/*.vue\" \"t/*.js\" --ignore-pattern assets/webpack.config.d",
     "lint:fix": "npm run lint -- --fix"
   },


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/191193