### PR TITLE
Avoid relying on Mojo webpack in tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Install dependencies
         run: |
           make install-deps-ubuntu install-deps-cpanm
+      - name: Build assets
+        run: make build
       - name: Run tests
         run: make test-unit
       - name: Run UI tests

--- a/t/ui.t
+++ b/t/ui.t
@@ -24,7 +24,6 @@ use Dashboard::Test;
 
 plan skip_all => 'set TEST_ONLINE to enable this test' unless $ENV{TEST_ONLINE};
 
-$ENV{MOJO_WEBPACK_BUILD} = 1;
 my $dashboard_test = Dashboard::Test->new(online => $ENV{TEST_ONLINE}, schema => 'ui_test');
 my $config         = $dashboard_test->default_config;
 my $t              = Test::Mojo->new(Dashboard => $config);

--- a/t/wrappers/ui.pl
+++ b/t/wrappers/ui.pl
@@ -10,7 +10,6 @@ use Mojo::File qw(curfile);
 use Test::Mojo;
 use Dashboard::Test;
 
-$ENV{MOJO_WEBPACK_BUILD} = 1;
 my $dashboard_test = Dashboard::Test->new(online => $ENV{TEST_ONLINE}, schema => 'js_ui_test');
 my $daemon         = Mojo::Server::Daemon->new(listen => ['http://*?fd=3'], silent => 1);
 


### PR DESCRIPTION
As explained in 9b84c9a5 and e7c5cf02, Mojo webpack has undesired behavior. Hence we also shouldn't run it implicitly in tests.

Related ticket: https://progress.opensuse.org/issues/191193