### PR TITLE
Avoid installing unwanted package versions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
-    - name: npm install
-      run: npm install --ignore-scripts
+    - name: npm clean-install
+      run: npm clean-install --ignore-scripts
     - name: npm run lint
       run: npm run lint

--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,7 @@ COPY . .
 # RUN git clone https://github.com/openSUSE/qem-dashboard .
 
 # Install node dependencies and bundle assets
-RUN npm install --ignore-scripts && \
+RUN npm clean-install --ignore-scripts && \
     npm run build && \
     npx playwright install
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 
 .PHONY: install-deps-js
 install-deps-js:
-	npm install --ignore-scripts
+	npm clean-install --ignore-scripts
 	npx playwright install --with-deps
 
 .PHONY: install-deps-ubuntu

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install all required dependencies, run
     sudo zypper in -C postgresql-server postgresql-contrib
     sudo zypper in -C perl-Mojolicious perl-Mojolicious-Plugin-Webpack \
       perl-Mojo-Pg perl-Cpanel-JSON-XS perl-JSON-Validator perl-IO-Socket-SSL nodejs-default npm
-    npm install --ignore-scripts
+    npm clean-install --ignore-scripts
 
 if you are on an apt-based system, run
 


### PR DESCRIPTION
The command `npm install` might modify `package.json` or the package-locks as explained in `npm help clean-install`. We should avoid this and only do updates explicitly (using Dependabot). Hence `npm clean-install` should be our default for installing npm packages.

Related ticket: https://progress.opensuse.org/issues/191193