### PR TITLE
fix: missing dependency for vite in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@mojojs/core": "^1.26.12",
     "@mojojs/path": "^1.7.0",
     "@mojolicious/server-starter": "^2.2.0",
+    "@vitejs/plugin-vue": "^6.0.3",
     "bootstrap": "^5.3.8",
     "date-fns": "^4.1.0",
     "eslint": "^9.39.2",
@@ -42,18 +43,17 @@
     "prettier": "^3.7.4",
     "sass": "^1.97.3",
     "tap": "^21.5.0",
+    "vite": "^7.3.1",
     "vue": "^3.5.26",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
-    "@vitejs/plugin-vue": "^6.0.3",
     "@vue/test-utils": "^2.4.6",
     "eslint-plugin-vuejs-accessibility": "^2.4.1",
     "husky": "^9.1.7",
     "jsdom": "^27.4.0",
     "lint-staged": "^16.2.7",
-    "vite": "^7.3.1",
     "vitest": "^4.0.17"
   }
 }


### PR DESCRIPTION
At least at SUSE we build assets in the production system at time of
deployment so we need vite during that time.