### PR TITLE
fix(dependabot): try another attempt to fix commit styles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
       - "waiting"
       - "dependencies"
     commit-message:
-      prefix: build
+      prefix: "chore"
       include: scope


### PR DESCRIPTION
openQA uses "chore" so let us try that. So far dependabot still creates
with a capital word "Build" after the colon.

Related progress issue: https://progress.opensuse.org/issues/196175