### PR TITLE
build: allow more subject cases in commitlint

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,11 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "body-max-line-length": [2, "always", 80]
+    "body-max-line-length": [2, "always", 80],
+    "subject-case": [
+      2,
+      "always",
+      ["lower-case", "sentence-case", "start-case", "pascal-case", "camel-case"]
+    ]
   }
 }


### PR DESCRIPTION
Allow sentence-case, start-case, pascal-case, and camel-case in commit
subjects. This accommodates Dependabot's commit message format, which
often starts with an uppercase letter (e.g., "chore(deps): Build..."),
preventing CI failures on its pull requests.