### PR TITLE
fix: allow direct navigation to submission route

### DIFF
--- a/assets/stores/submission_detail.js
+++ b/assets/stores/submission_detail.js
@@ -10,7 +10,7 @@ export const useSubmissionDetailStore = defineStore('submission_detail', {
   actions: {
     async fetchSubmission(id) {
       try {
-        const data = await fetch(`/app/api/incident/${id}`).then(res => res.json());
+        const data = await fetch(`/app/api/submission/${id}`).then(res => res.json());
         this.submission = data.details.incident;
         this.submission.buildNr = data.details.build_nr;
         this.jobs = data.details.jobs;

--- a/lib/Dashboard.pm
+++ b/lib/Dashboard.pm
@@ -190,11 +190,13 @@ sub _register_routes ($self, $config) {
   $json->get('/blocked')->to('overview#blocked');
   $json->get('/repos')->to('overview#repos');
   $json->get('/incident/<incident:num>')->to('overview#incident');
+  $json->get('/submission/<incident:num>')->to('overview#incident');
 
   # Catch all for delivering the webpack UI
   $public->get('/')->to('overview#index')->name('index');
   $public->get('/:name' => [name => ['repos', 'blocked']])->to('overview#index');
   $public->get('/incident/<incident:num>')->to('overview#index');
+  $public->get('/submission/<incident:num>')->to('overview#index');
 
   # API (v1 and legacy)
   my $register_api_routes = sub ($api) {

--- a/t/ui.t.js
+++ b/t/ui.t.js
@@ -152,6 +152,13 @@ t.test('Test dashboard ui', {skip, timeout: 60000}, async t => {
     t.equal(await page.innerText('.container p'), 'Incident does not exist.');
   });
 
+  await t.test('Direct navigation to submission', async t => {
+    await page.goto(`${url}/submission/16860`);
+    await page.waitForSelector('.packages ul');
+    t.equal(await page.innerText('title'), 'Details for Submission');
+    t.match(await page.innerText('.packages ul'), /perl-Mojolicious/);
+  });
+
   await t.test('Repos page detailed interactions', async t => {
     await page.goto(`${url}/repos`);
     await page.waitForSelector('tbody tr');


### PR DESCRIPTION
Add backend routes for '/submission/' to ensure deep-linking and page
refreshes work correctly. Previously, only the frontend router handled
this path, causing 404 errors on direct navigation.

* Add '/submission/' to JSON API and catch-all routes in Dashboard.pm
* Update frontend store to use consistent '/app/api/submission/' endpoint
* Add UI regression test for direct navigation