### PR TITLE
feat: add container/devel definitions

### DIFF
--- a/container/devel/Containerfile
+++ b/container/devel/Containerfile
@@ -18,6 +18,7 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 
 # hadolint ignore=DL3037
 RUN zypper in -y -C \
+    retry \
     perl-Mojolicious \
     perl-Mojolicious-Plugin-Webpack \
     perl-Mojo-Pg \

--- a/container/devel/Containerfile
+++ b/container/devel/Containerfile
@@ -1,0 +1,29 @@
+# Specify the license of the container build description (see also the LICENSE file)
+# SPDX-License-Identifier: MIT
+# Define the names/tags of the container
+#!BuildTag: opensuse/qem-dashboard_devel:latest opensuse/qem-dashboard_devel:%RELEASE%
+
+# hadolint ignore=DL3006
+FROM opensuse/tumbleweed
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=org.opensuse.qem-dashboard_devel
+LABEL org.opencontainers.image.title="qem-dashboard devel container"
+LABEL org.opencontainers.image.description="qem-dashboard development container"
+LABEL org.opencontainers.image.version="%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/opensuse/qem-dashboard_devel:%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
+
+# hadolint ignore=DL3037
+RUN zypper in -y -C \
+    perl-Mojolicious \
+    perl-Mojolicious-Plugin-Webpack \
+    perl-Mojo-Pg \
+    perl-Cpanel-JSON-XS \
+    perl-JSON-Validator \
+    perl-IO-Socket-SSL \
+    nodejs-default \
+    npm && \
+    zypper clean -a

--- a/container/devel/Dockerfile
+++ b/container/devel/Dockerfile
@@ -1,0 +1,1 @@
+Containerfile

--- a/container/devel/_service
+++ b/container/devel/_service
@@ -1,0 +1,15 @@
+<services>
+  <service name="obs_scm">
+    <param name="url">https://github.com/openSUSE/qem-dashboard</param>
+    <param name="scm">git</param>
+    <param name="revision">feature/container_devel</param>
+    <param name="versionprefix">1</param>
+    <param name="versionformat">%ct.%h</param>
+    <param name="subdir">container/devel</param>
+    <param name="extract">Dockerfile</param>
+    <param name="changesgenerate">enable</param>
+    <param name="changesauthor">okurz@suse.de</param>
+  </service>
+  <service name="kiwi_metainfo_helper" mode="buildtime"/>
+  <service name="docker_label_helper" mode="buildtime"/>
+</services>


### PR DESCRIPTION
* feat(container/devel): add _service
* feat(container/devel): add symlink for OBS support
* feat: add devel Containerfile

This container can be used for local development as well as in CI tests, e.g. in the qem-dashboard integration tests of qem-bot https://github.com/openSUSE/qem-bot/pull/462