### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/checkstyle_npm.yml
+++ b/.github/workflows/checkstyle_npm.yml
@@ -6,7 +6,7 @@ jobs:
   checkstyle-npm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - uses: actions/setup-node@v6.2.0

--- a/.github/workflows/checkstyle_perl.yml
+++ b/.github/workflows/checkstyle_perl.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: perl:5.42
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Fix git permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: perl -V

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: shogo82148/actions-setup-perl@v1
       - uses: actions/setup-node@v6.2.0
         with:


### PR DESCRIPTION
This also fixes a warning about outdated nodejs