### PR TITLE
chore(dependabot): add semver cooldown for updates to prevent PR fatigue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      semver-patch-days: 7
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
@@ -18,3 +20,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      semver-patch-days: 7


### PR DESCRIPTION
Motivation:
Reduce the frequency of Dependabot pull requests by delaying updates based on
semantic versioning levels. This provides a buffer to ensure that new versions
are stable before they are proposed for integration.

Benefits:
- Improved stability by avoiding "day zero" bugs in dependencies.
- Reduced noise and review overhead for the development team.

Before:
* #3290