### PR TITLE
chore(dependabot): group minor/patch dev-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
       prefix: "chore"
       include: scope
     groups:
+      dev-dependencies:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
       patch-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
Motivation:
Bundle minor and patch updates for development dependencies into a single PR
to reduce noise. Major updates remain separate as they likely require manual
review for breaking changes.

Benefits:
- Cleaner PR list.
- Faster merging of low-risk development dependency updates.