### PR TITLE
fix: replace semver where it is not supported

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
       interval: "weekly"
       day: "monday"
     cooldown:
-      semver-patch-days: 7
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       all-actions:


### PR DESCRIPTION


Github Actions does not support semver
so replacing it with default-days
