### PR TITLE
build: broaden gitlint ignore rules for Dependabot

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -9,5 +9,5 @@ regex=^https?:\/\/\S+$
 
 [ignore-by-title]
 # Dependabot creates non-conventional commits we need to accept
-regex=^chore\(deps\): Bump
+regex=^(chore|build)\(deps(-dev)?\):|^Bump [^ ]+ from
 ignore=all


### PR DESCRIPTION
Motivation:
Dependabot creates various commit message formats that do not always follow
the conventional commits specification enforced by our gitlint configuration.
This was causing CI failures on Dependabot PRs.

Design Choices:
Updated the title-based ignore rule to include more Dependabot patterns,
specifically adding support for 'deps-dev' and the 'Bump <pkg> from' format.
This allows most Dependabot-generated commits to be ignored by gitlint.

Benefits:
Ensures that Dependabot-generated PRs can pass CI without manual intervention
while still maintaining strict commit message standards for human contributors.

Related issue: https://github.com/openSUSE/qem-dashboard/pull/3306