### PR TITLE
build: limit gitlint to PR commits and improve base branch detection

### DIFF
--- a/.github/workflows/checkstyle_npm.yml
+++ b/.github/workflows/checkstyle_npm.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Run checkstyle
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          make checkstyle-npm COMMIT_ARGS="--commits ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --verbose"
+          make checkstyle-npm COMMIT_ARGS="--commits origin/${{ github.base_ref }}..HEAD --verbose"
         else
           make checkstyle-npm COMMIT_ARGS="--commits HEAD --verbose"
         fi

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ HARNESS_PERL_SWITCHES ?= -MDevel::Cover=-ignore,^blib/,-ignore,^templates/,-igno
 COVERAGE_OPTS ?= PERL5OPT='$(HARNESS_PERL_SWITCHES)'
 TEST_WRAPPER_COVERAGE ?= 1
 ASSET_SOURCES := $(shell find assets -type f) package-lock.json vite.config.js vitest.config.js
-BASE_BRANCH := $(shell BASES=$$(for i in origin/main main master; do git rev-parse --verify $$i 2>/dev/null; done ||:); git merge-base --independent $$BASES | head -n 1)
-COMMIT_ARGS ?= --commits $(if $(BASE_BRANCH),$(BASE_BRANCH)..HEAD,HEAD)
+BASE_BRANCH := $(shell BASES=$$(for i in upstream/main upstream/master origin/main origin/master main master; do git rev-parse --verify $$i 2>/dev/null; done ||:); git merge-base --independent $$BASES | head -n 1)
+COMMIT_ARGS ?= --commits $(if $(BASE_BRANCH),$(BASE_BRANCH)..HEAD,HEAD) --verbose
 PROVE ?= tools/prove_wrapper
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
Motivation:
The gitlint check was failing in CI because it was attempting to lint too
many commits, including ancient ones already in the main branch. This happened
because the base branch detection was not robust enough and the PR commit
range was not accurately defined in the workflow.

Design Choices:
1. Updated the Makefile to use a more robust base branch detection logic
   (inspired by openQA), which checks multiple common branch names and
   finds the best merge base.
2. Added --verbose to the gitlint command in the Makefile for better
   diagnostics.
3. Updated the checkstyle (NPM) workflow to use origin/${{ github.base_ref }}
   as the base for pull requests, ensuring only the commits introduced in the
   PR are linted.

Benefits:
Fixes CI failures on pull requests by ensuring only relevant commits are
checked for compliance with commit message standards.