### PR TITLE
ci: improve gitlint commit range detection on push

### DIFF
--- a/.github/workflows/checkstyle_npm.yml
+++ b/.github/workflows/checkstyle_npm.yml
@@ -21,5 +21,10 @@ jobs:
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           make checkstyle-npm COMMIT_ARGS="--commits origin/${{ github.base_ref }}..HEAD --verbose"
         else
-          make checkstyle-npm COMMIT_ARGS="--commits HEAD --verbose"
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" == "0000000000000000000000000000000000000000" ]; then
+            make checkstyle-npm COMMIT_ARGS="--verbose"
+          else
+            make checkstyle-npm COMMIT_ARGS="--commits $BEFORE..${{ github.event.after }} --verbose"
+          fi
         fi


### PR DESCRIPTION
Motivation:
On 'push' events, gitlint was incorrectly instructed to lint 'HEAD', which it
interprets as the entire reachable history. This caused CI failures on main
branches due to ancient commits that do not match current standards.

Design Choices:
Updated 'checkstyle_npm.yml' to use the '${{ github.event.before }}..${{
github.event.after }}' range for 'push' events. Added a safeguard for branch
creation (where the 'before' SHA is all zeros) to fallback to linting only the
latest commit. The all-zeros SHA (Null OID) is the standard placeholder for
the absence of a commit, as documented in https://git-scm.com/docs/githooks.

Benefits:
Ensures stable 'push' checks on main branches by only linting the newly
introduced commits.

Related issue: https://github.com/openSUSE/qem-dashboard/pull/3311