### PR TITLE
ci: prevent redundant CI runs for internal PRs

### DIFF
--- a/.github/workflows/checkstyle_npm.yml
+++ b/.github/workflows/checkstyle_npm.yml
@@ -4,6 +4,7 @@ name: checkstyle (NPM)
 on: [push, pull_request]
 jobs:
   checkstyle-npm:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/.github/workflows/checkstyle_perl.yml
+++ b/.github/workflows/checkstyle_perl.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 jobs:
   checkstyle-perl:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     container:
       image: perl:5.42

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 jobs:
   only-test:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
Motivation:
Workflows trigger on both 'push' and 'pull_request' events for internal
branches, leading to duplicate CI runs. Developers want CI feedback on all
pushes, but redundant runs on PRs are unnecessary and wasteful.

Design Choices:
Added a job-level 'if' condition to all workflow jobs. The logic allows the job
to run if it's a 'push' event OR if it's a 'pull_request' event from a fork.
Internal PRs (where the head repo matches the base repo) will be skipped by
the 'pull_request' trigger, relying instead on the existing 'push' run for
that branch.

Benefits:
- Eliminates duplicate CI runs for internal contributors.
- Maintains immediate feedback for all branch pushes.
- Ensures cross-repository PRs (forks) still trigger CI correctly.

Related issue: https://github.com/openSUSE/qem-dashboard/pull/3311