### PR TITLE
ci: improve gitlint range detection by verifying commit existence

### DIFF
--- a/.github/workflows/checkstyle_npm.yml
+++ b/.github/workflows/checkstyle_npm.yml
@@ -24,7 +24,7 @@ jobs:
         else
           BEFORE="${{ github.event.before }}"
           AFTER="${{ github.event.after }}"
-          if [ "$BEFORE" == "0000000000000000000000000000000000000000" ] || ! git rev-parse --verify "$BEFORE" >/dev/null 2>&1; then
+          if [ "$BEFORE" == "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE" >/dev/null 2>&1; then
             make checkstyle-npm COMMIT_ARGS="--verbose"
           else
             make checkstyle-npm COMMIT_ARGS="--commits $BEFORE..$AFTER --verbose"


### PR DESCRIPTION
Motivation
On 'push' events, gitlint was failing with 'fatal: Invalid revision range'
because the 'before' SHA provided by GitHub was not always present in the local
clone (e.g., after force-pushes or rebases). The existing check using
'git rev-parse --verify' was insufficient because it only validates SHA format
for 40-character strings, rather than confirming the commit exists in the
object database.

Design Choices
Replaced 'git rev-parse --verify "$BEFORE"' with 'git cat-file -e "$BEFORE"' in
the checkstyle-npm workflow. Unlike 'rev-parse', 'cat-file -e' explicitly
validates that the object exists in the local repository. If the commit is
missing, the script now correctly falls back to linting only the latest commit.

Benefits
Prevents spurious CI failures on branches with rewritten history while ensuring
new commits are still properly linted.