### PR TITLE
fix: exclude multiple CPAN security advisories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,17 @@ check-audits-cpan: ## Run security audits for Perl dependencies
 	#   See https://www.cve.org/CVERecord?id=CVE-2026-27171
 	# CPANSA-HTTP-Tiny-2026-7010: CVE-2026-7010 (CRLF injection)
 	#   See https://github.com/Perl-Toolchain-Gang/HTTP-Tiny/commit/d73c7651e82ace02693842df55928b6c3ae7c38d.patch
+	# CPANSA-perl-2026-8376: CVE-2026-8376 heap buffer overflow on 32-bit builds (not applicable)
+	#   See https://github.com/Perl/perl5/commit/5e7f119eb2bb1181be908701f22bf7068e722f1c.patch
+	# CPANSA-IO-Compress-2025-15649, CPANSA-IO-Compress-2026-48959, CPANSA-IO-Compress-2026-48961, CPANSA-IO-Compress-2026-48962:
+	#   CVE-2025-15649, CVE-2026-48959, CVE-2026-48961, CVE-2026-48962 (not exploitable/not used)
+	#   See https://github.com/pmqs/IO-Compress/commit/fd28c1d2374eee9811f6d0c5bddc0957abdf1da8.patch
+	# CPANSA-Cpanel-JSON-XS-2026-9516, CPANSA-Cpanel-JSON-XS-2026-9334:
+	#   CVE-2026-9516, CVE-2026-9334 (not exploitable)
+	#   See https://github.com/rurban/Cpanel-JSON-XS/commit/dfe1b41a36caba51dc12a2917fe50285d1ffaa7b.patch
+	# CPANSA-Archive-Tar-2026-42496, CPANSA-Archive-Tar-2026-9538, CPANSA-Archive-Tar-2026-42497:
+	#   CVE-2026-42496, CVE-2026-9538, CVE-2026-42497 (transitive / not extracting untrusted archives)
+	#   See https://github.com/jib/archive-tar-new/commit/17c873492a05eddc0de18c1485e0b2cccd5a9158.patch
 	PERL5LIB=~/perl5/lib/perl5:$$PERL5LIB PATH=~/perl5/bin:$$PATH cpan-audit deps . \
 		--exclude CPANSA-Mojolicious-2024-58134 \
 		--exclude CPANSA-Mojolicious-2024-58135 \
@@ -122,7 +133,17 @@ check-audits-cpan: ## Run security audits for Perl dependencies
 		--exclude CPANSA-YAML-LibYAML-2016-01 \
 		--exclude CPANSA-Compress-Raw-Zlib-2026-3381 \
 		--exclude CPANSA-perl-2026-4176 \
-		--exclude CPANSA-HTTP-Tiny-2026-7010
+		--exclude CPANSA-HTTP-Tiny-2026-7010 \
+		--exclude CPANSA-perl-2026-8376 \
+		--exclude CPANSA-IO-Compress-2025-15649 \
+		--exclude CPANSA-IO-Compress-2026-48959 \
+		--exclude CPANSA-IO-Compress-2026-48961 \
+		--exclude CPANSA-IO-Compress-2026-48962 \
+		--exclude CPANSA-Cpanel-JSON-XS-2026-9516 \
+		--exclude CPANSA-Cpanel-JSON-XS-2026-9334 \
+		--exclude CPANSA-Archive-Tar-2026-42496 \
+		--exclude CPANSA-Archive-Tar-2026-9538 \
+		--exclude CPANSA-Archive-Tar-2026-42497
 
 .PHONY: check-audits-npm
 check-audits-npm: ## Run security audits for JS dependencies


### PR DESCRIPTION
Motivation:
A set of new upstream security advisories were flagged by cpan-audit on perl,
IO-Compress, Cpanel-JSON-XS, and Archive-Tar. These vulnerabilities are either
unapplicable to our 64-bit platform, transitive dependencies whose unsafe code
paths are not reached by our application, or only relevant for extracting
untrusted archive files which our system does not do.