### PR TITLE
fix: prevent icons from overflowing adjacent column

### DIFF
--- a/assets/vue/components/SubmissionDetailsIcons.vue
+++ b/assets/vue/components/SubmissionDetailsIcons.vue
@@ -22,7 +22,7 @@ const priorityBadgeClass = computed(() => {
 </script>
 
 <template>
-  <div class="submission-details-icons d-inline-flex gap-2">
+  <div class="submission-details-icons d-inline-flex flex-wrap gap-2">
     <i
       class="fas"
       :class="incident.approved ? 'fa-stamp text-success' : 'fa-stamp text-secondary opacity-50'"


### PR DESCRIPTION
Icons in a flex container could exceed the fixed 250px column width, causing them to visually overlap the results pills column.