### PR TITLE
Deployed version

### DIFF
--- a/lib/Dashboard.pm
+++ b/lib/Dashboard.pm
@@ -40,6 +40,11 @@ sub startup ($self) {
 
   $self->secrets($config->{secrets});
 
+  chomp(my $git_hash = qx{git rev-parse --short HEAD 2>/dev/null}           || 'unknown');
+  chomp(my $git_date = qx{git log -1 --format=%cd --date=short 2>/dev/null} || 'unknown');
+  $self->{git_hash} = $git_hash;
+  $self->{git_date} = $git_date;
+
   # Show IPv6 compatible "localhost" instead of IPv4 loopback 127.0.0.1
   $ENV{MOJO_LISTEN} //= 'http://localhost:3000';
 
@@ -124,6 +129,9 @@ EOF
   $self->plugin('Dashboard::Plugin::JSON');
   $self->plugin('Dashboard::Plugin::Helpers');
   $self->plugin('Dashboard::Plugin::Database', $config);
+
+  $self->helper(git_hash => sub { $self->{git_hash} });
+  $self->helper(git_date => sub { $self->{git_date} });
 
   # Serve Swagger UI assets from npm package
   push @{$self->static->paths}, $self->home->child('node_modules', 'swagger-ui-dist');

--- a/templates/overview/index.html.ep
+++ b/templates/overview/index.html.ep
@@ -14,13 +14,23 @@
     </div>
 
     <footer class='footer'>
-      <div class='container'>
-        <div id='footer-legal' class="text-center">
+      <div class='container d-flex align-items-center px-3 h-100'>
+        <span class='me-auto small text-muted'>
+          Version:
+          % if (git_hash() ne 'unknown') {
+            <a href="https://github.com/openSUSE/qem-dashboard/commit/<%= git_hash %>"><%= git_hash %></a>
+          % } else {
+            unknown
+          % }
+          % if (git_date() ne 'unknown') {
+            (<%= git_date %>)
+          % }
+        </span>
+        <span class='small text-muted'>
           QEM Dashboard is maintained on
-          <a href="https://github.com/openSUSE/qem-dashboard">
-            GitHub.
-          </a>&copy; <a href="https://suse.com">SUSE</a>.
-        </div>
+          <a href="https://github.com/openSUSE/qem-dashboard">GitHub.</a>
+          &copy; <a href="https://suse.com">SUSE</a>.
+        </span>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
**As a user**, the app currently shows no information about what version is deployed. This PR adds a version badge in the footer (linked to a changelog page) so users can:
* See at a glance what version is running
* Click through to the changelog to learn what features and fixes have been delivered

**As a contributor**, I want to easily know what version is deployed so when investigating a bug I can understand the potential diff between the deployed version and the current main HEAD.

This is only a proposal. I assume you might opt for more rolling-releases style, so we would rather show currently deployed git hash. That would be also fine and I'm happy to see how to get that implemented.
I'm proposing this, as it is easy, quick and can open a discussion if this is needed and accepted to begin with.