### PR TITLE
build(make): optimize ASSET_SOURCES build triggers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_ONLINE ?= postgresql://postgres:postgres@localhost:5432/postgres
 HARNESS_PERL_SWITCHES ?= -MDevel::Cover=-ignore,^blib/,-ignore,^templates/,-ignore,Net/SSLeay,-ignore,Dashboard/Plugin/Database.pm
 COVERAGE_OPTS ?= PERL5OPT='$(HARNESS_PERL_SWITCHES)'
 TEST_WRAPPER_COVERAGE ?= 1
-ASSET_SOURCES := $(shell find assets -type f) package-lock.json vite.config.js vitest.config.js
+ASSET_SOURCES := $(shell find assets -type f) package.json vite.config.js vitest.config.js
 BASE_BRANCH := $(shell BASES=$$(for i in upstream/main upstream/master origin/main origin/master main master; do git rev-parse --verify $$i 2>/dev/null; done ||:); git merge-base --independent $$BASES | head -n 1)
 COMMIT_ARGS ?= --commits $(if $(BASE_BRANCH),$(BASE_BRANCH)..HEAD,HEAD) --verbose
 PROVE ?= tools/prove_wrapper


### PR DESCRIPTION
Motivation:
`package-lock.json` changes on every audit fix or indirect dependency
update, triggering unnecessary asset builds. `package.json` is a better
trigger for direct dependency changes that affect the build output.

Design Choices:
- Replaced `package-lock.json` with `package.json` in `ASSET_SOURCES`.

User Benefits:
- Reduced frequency of unnecessary asset builds during development and
  maintenance.