### PR TITLE
ci(dependabot): remove updates grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,18 +15,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    groups:
-      dev-dependencies:
-        applies-to: version-updates
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-      patch-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
@@ -35,7 +23,3 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
-    groups:
-      all-actions:
-        patterns:
-          - "*"


### PR DESCRIPTION


Initially idea of grouping was to avoid spamming
 but it appears that amount of spam remains
 the same just concentrated in single PR instead
 of several.
Also single PR for several updates makes overall
 dependency management more complicated
