### PR TITLE
ci(dependabot): decrease frequency for none critical updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Production dependencies - daily updates
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -7,7 +8,7 @@ updates:
     cooldown:
       semver-patch-days: 7
     allow:
-      - dependency-type: "all"
+      - dependency-type: "production"
     open-pull-requests-limit: 5
     labels:
       - "waiting"
@@ -15,22 +16,27 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    groups:
-      dev-dependencies:
-        applies-to: version-updates
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-      patch-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
+  # Development dependencies - monthly updates
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+      day: 'monday'
+    cooldown:
+      semver-patch-days: 7
+    allow:
+      - dependency-type: "development"
+    open-pull-requests-limit: 5
+    labels:
+      - "waiting"
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: scope
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
     cooldown:
       default-days: 7


### PR DESCRIPTION


Packages involved in code analysis and package development
are not so sensetive for frequent updates. To lower
burden on PR reviewers we can instruct dependabot
to produce PR less frequent only for this type of
packages.
