### PR TITLE
fix(mergify): prevent endless dependabot PR recreation loops

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,25 +39,13 @@ pull_request_rules:
         # one from the base checks
         - base=main
         - author=dependabot[bot]
-        - "label=waited"
     actions:
       queue:
       merge:
         method: squash
-  - name: Wait for some time before validating merge
-    actions:
-      label:
-        add:
-          - waited
-        remove:
-          - waiting
+  - name: continuously rebase pull requests when it's labeled with `rebase`
     conditions:
-      - and:
-          - updated-at<4 days ago
-          - author=dependabot[bot]
-  - name: continuously rebase pull requests when it's labeled with `rebase` or `waited`
-    conditions:
-      - label~=rebase|waited
+      - label=rebase
     actions:
       rebase:
         bot_account: suse-qe-tools-mergify


### PR DESCRIPTION
Motivation:
Dependabot's daily updates reset Mergify's 4-day wait timer. This causes
the PRs to close and reopen in an endless loop.

Design Choices:
Remove the 4-day wait rule and use Dependabot's built-in 7-day cooldown
instead, which naturally handles supply chain risks.

Benefits:
Stops the endless PR loops while maintaining secure automated updates.