### PR TITLE
fix: use app home dir for git commands to work regardless of cwd

### DIFF
--- a/lib/Dashboard.pm
+++ b/lib/Dashboard.pm
@@ -40,10 +40,9 @@ sub startup ($self) {
 
   $self->secrets($config->{secrets});
 
-  chomp(my $git_hash = qx{git rev-parse --short HEAD 2>/dev/null}           || 'unknown');
-  chomp(my $git_date = qx{git log -1 --format=%cd --date=short 2>/dev/null} || 'unknown');
-  $self->{git_hash} = $git_hash;
-  $self->{git_date} = $git_date;
+  my $dir = $self->home;
+  chomp(my $git_info = qx{git -C "$dir" log -1 --format="%h %cd" --date=short 2>/dev/null} || "unknown unknown");
+  ($self->{git_hash}, $self->{git_date}) = split ' ', $git_info;
 
   # Show IPv6 compatible "localhost" instead of IPv4 loopback 127.0.0.1
   $ENV{MOJO_LISTEN} //= 'http://localhost:3000';


### PR DESCRIPTION
So I could now see the server where this app is deployed.
Looks the path is: `/home/lurklur/qem-dashboard`

So the fix should do.
I check in the server:
```
qam2:~ # git -C /home/lurklur/qem-dashboard rev-parse --short HEAD 2>/dev/null
4d8f2e0
```

I assume this is ok `my $dir = $self->home;`
but I am not sure how to make sure this will work well on the server. Locally, when I check, all works.
