### PR TITLE
ci: disable Mergify interactive queue controls in PR comments

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,8 @@
+---
 merge_queue:
   max_parallel_checks: 1
+  status_comments: none
+  queue_controls_comment: false
 
 queue_rules:
   - name: default


### PR DESCRIPTION
Motivation:
Rendered task-list checkboxes in the Merge Queue status comment could be
clicked accidentally by reviewers, triggering unexpected merges before
the required approval count was met.

Design Choices:
Set queue_controls_comment to false in the merge_queue block of
.mergify.yml to disable rendering these interactive controls.

Benefits:
Prevents accidental manual queueing and merging of pull requests while
allowing automated queues like Dependabot to work normally.