### PR TITLE
feat: show aggregated code stream inline on blocked test badges

### DIFF
--- a/assets/vue/App.vue
+++ b/assets/vue/App.vue
@@ -180,6 +180,11 @@ body {
   list-style-type: none;
   padding-bottom: 0.2em;
   padding-right: 0.2em;
+  vertical-align: top;
+}
+.summary-list li small {
+  font-size: 0.7em;
+  line-height: 1.2;
 }
 .table tbody {
   border-top: 0 !important;

--- a/assets/vue/components/BlockedSubmissionUpdResult.vue
+++ b/assets/vue/components/BlockedSubmissionUpdResult.vue
@@ -18,7 +18,9 @@ const title = computed(() => {
 
 <template>
   <li :group-id="groupId" data-bs-toggle="tooltip" data-bs-placement="left" :title="title">
-    <ResultSummary :result="result" />
+    <ResultSummary :result="result">
+      <template #subtitle>{{ title }}</template>
+    </ResultSummary>
   </li>
 </template>
 

--- a/assets/vue/components/ResultSummary.vue
+++ b/assets/vue/components/ResultSummary.vue
@@ -50,9 +50,20 @@ const link = computed(() => {
 </script>
 
 <template>
-  <a v-if="currentConfig" :href="link" class="btn" :class="currentConfig.btnClass" target="_blank">
-    <i class="fas me-1" :class="currentConfig.iconClass" aria-hidden="true"></i>
-    {{ result.name }} <span class="badge bg-light text-dark">{{ counts }}</span>
+  <a
+    v-if="currentConfig"
+    :href="link"
+    class="btn d-inline-flex flex-column align-items-center"
+    :class="currentConfig.btnClass"
+    target="_blank"
+  >
+    <span>
+      <i class="fas me-1" :class="currentConfig.iconClass" aria-hidden="true"></i>
+      {{ result.name }} <span class="badge bg-light text-dark">{{ counts }}</span>
+    </span>
+    <small class="opacity-75 subtitle" :class="{invisible: !$slots.subtitle}">
+      <slot name="subtitle">&nbsp;</slot>
+    </small>
     <span class="visually-hidden">{{ currentConfig.label }}</span>
   </a>
   <a v-else>


### PR DESCRIPTION
The version/flavor being aggregated under "Group Flavors" was only visible via hover tooltip. Surface it as a visible line inside the result pill so it's readable without hovering. This is useful while doing the review of multiple runs, for instance KLP, as it provides quick information without the need to hover over each pill.

After the change:
<img width="1410" height="689" alt="Screenshot from 2026-07-17 05-42-02" src="https://github.com/user-attachments/assets/586376d0-a332-4fbf-a5e0-9e6438e83716" />
