### PR TITLE
fix: prefer kernel-default package name over others on submission badges

### DIFF
--- a/assets/vue/components/SubmissionLink.vue
+++ b/assets/vue/components/SubmissionLink.vue
@@ -21,6 +21,7 @@
 
 <script setup>
 import {ref, computed} from 'vue';
+import {getPrimaryPackage} from '../helpers/packages.js';
 
 defineOptions({
   name: 'SubmissionLink'
@@ -33,7 +34,7 @@ const props = defineProps({
 
 const copied = ref(false);
 
-const packageName = computed(() => props.incident.packages[0]);
+const packageName = computed(() => getPrimaryPackage(props.incident.packages));
 
 const copyToClipboard = async () => {
   try {

--- a/assets/vue/helpers/packages.js
+++ b/assets/vue/helpers/packages.js
@@ -1,0 +1,5 @@
+export function getPrimaryPackage(packages) {
+  if (!packages || packages.length === 0) return undefined;
+  if (packages.includes('kernel-default')) return 'kernel-default';
+  return packages[0];
+}

--- a/assets/vue/helpers/packages.test.js
+++ b/assets/vue/helpers/packages.test.js
@@ -1,0 +1,17 @@
+import {describe, it, expect} from 'vitest';
+import {getPrimaryPackage} from './packages';
+
+describe('getPrimaryPackage', () => {
+  it('prefers kernel-default over other packages', () => {
+    expect(getPrimaryPackage(['dtb-aarch64', 'kernel-default'])).toBe('kernel-default');
+  });
+
+  it('falls back to the first package when kernel-default is absent', () => {
+    expect(getPrimaryPackage(['dtb-aarch64', 'kernel-syzkaller'])).toBe('dtb-aarch64');
+  });
+
+  it('returns undefined for an empty or missing list', () => {
+    expect(getPrimaryPackage([])).toBeUndefined();
+    expect(getPrimaryPackage(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Submissions with multiple packages (e.g. dtb-aarch64 alongside kernel-default) showed whichever package happened to be first in the array. Prefer kernel-default when present so it's shown instead.

Discussion: https://suse.slack.com/archives/C02CANHLANP/p1784286816025179