### PR TITLE
feat: support SMELT slfo-beta links for Gitea PRs

### DIFF
--- a/assets/vue/components/PageSubmission.vue
+++ b/assets/vue/components/PageSubmission.vue
@@ -9,12 +9,18 @@ import StatusBadge from './StatusBadge.vue';
 import RequestLink from './RequestLink.vue';
 import SmeltLink from './SmeltLink.vue';
 import SubmissionDetailsIcons from './SubmissionDetailsIcons.vue';
+import {getGitSmeltUrl} from '../utils/smelt';
 
 const route = useRoute();
 const submissionDetailStore = useSubmissionDetailStore();
 const configStore = useConfigStore();
 
 usePolling(() => submissionDetailStore.fetchSubmission(route.params.id));
+
+const hasSmeltLink = computed(() => {
+  const sub = submissionDetailStore.submission;
+  return Boolean(sub && (['ibs', 'smelt'].includes(sub.type || 'ibs') || getGitSmeltUrl(sub, configStore.smeltUrl)));
+});
 
 const results = computed(() => {
   if (!submissionDetailStore.summary) return [];
@@ -60,7 +66,7 @@ const sortedBuilds = computed(() => {
           </li>
         </ul>
       </div>
-      <div class="smelt-link" v-if="['ibs', 'smelt'].includes(submissionDetailStore.submission.type || 'ibs')">
+      <div class="smelt-link" v-if="hasSmeltLink">
         <h2>Link to Smelt</h2>
         <p>
           <SmeltLink :incident="submissionDetailStore.submission" />

--- a/assets/vue/components/RequestLink.test.js
+++ b/assets/vue/components/RequestLink.test.js
@@ -1,0 +1,52 @@
+import {describe, it, expect, vi} from 'vitest';
+import {mount} from '@vue/test-utils';
+import RequestLink from './RequestLink.vue';
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    obsUrl: 'https://build.example.com',
+    smeltUrl: 'https://smelt.example.com'
+  })
+}));
+
+describe('RequestLink.vue', () => {
+  it('renders the git submission link with PR prefix and SMELT badge', () => {
+    const incident = {
+      type: 'git',
+      number: 6416,
+      packages: ['test-package'],
+      url: 'https://src.suse.de/products/SLFO/pulls/6416',
+      project: 'products/SLFO'
+    };
+
+    const wrapper = mount(RequestLink, {props: {incident}});
+
+    expect(wrapper.text()).toContain('PR #6416');
+    expect(wrapper.find('.rr-link').attributes('href')).toBe('https://src.suse.de/products/SLFO/pulls/6416');
+    expect(wrapper.find('.fa-code-branch').exists()).toBe(true);
+
+    const smeltBadge = wrapper.find('.badge');
+    expect(smeltBadge.text()).toBe('SMELT');
+    expect(smeltBadge.attributes('href')).toBe(
+      'https://smelt.example.com/slfo-beta/updates/src.suse.de:products:SLFO:6416'
+    );
+  });
+
+  it('does not render SMELT badge for legacy submissions', () => {
+    const incident = {type: 'ibs', number: 12345, rr_number: 9999, packages: ['test-package']};
+
+    const wrapper = mount(RequestLink, {props: {incident}});
+
+    expect(wrapper.find('.badge').exists()).toBe(false);
+  });
+
+  it('renders the legacy IBS/OBS request link with rr_number', () => {
+    const incident = {type: 'ibs', number: 12345, rr_number: 9999, packages: ['test-package']};
+
+    const wrapper = mount(RequestLink, {props: {incident}});
+
+    expect(wrapper.text()).toContain('9999:test-package');
+    expect(wrapper.find('.rr-link').attributes('href')).toBe('https://build.example.com/request/show/9999');
+    expect(wrapper.find('.fa-box-open').exists()).toBe(true);
+  });
+});

--- a/assets/vue/components/RequestLink.vue
+++ b/assets/vue/components/RequestLink.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed} from 'vue';
 import {useConfigStore} from '@/stores/config';
+import {firstPackage, getGitSmeltUrl} from '../utils/smelt';
 
 const props = defineProps({
   incident: {type: Object, required: true}
@@ -8,34 +9,41 @@ const props = defineProps({
 
 const configStore = useConfigStore();
 
-const packageName = computed(() =>
-  props.incident.packages && props.incident.packages.length > 0 ? props.incident.packages[0] : ''
+const packageName = computed(() => firstPackage(props.incident));
+
+const sourceUrl = computed(() =>
+  props.incident.type === 'git' || !props.incident.rr_number
+    ? props.incident.url
+    : `${configStore.obsUrl}/request/show/${props.incident.rr_number}`
 );
 
-const sourceUrl = computed(() => {
-  if (props.incident.type === 'git' || !props.incident.rr_number) {
-    return props.incident.url;
-  }
-  return `${configStore.obsUrl}/request/show/${props.incident.rr_number}`;
-});
+const linkText = computed(() =>
+  props.incident.type === 'git'
+    ? `PR #${props.incident.number}`
+    : props.incident.rr_number
+      ? `${props.incident.rr_number}:${packageName.value}`
+      : packageName.value || 'Source'
+);
 
-const linkText = computed(() => {
-  if (props.incident.rr_number) {
-    return `${props.incident.rr_number}:${packageName.value}`;
-  }
-  return packageName.value || 'Source';
-});
+const sourceIcon = computed(() => (props.incident.type === 'git' ? 'fas fa-code-branch' : 'fas fa-box-open'));
 
-const sourceIcon = computed(() => {
-  return props.incident.type === 'git' ? 'fas fa-code-branch' : 'fas fa-box-open';
-});
+const gitSmeltUrl = computed(() => getGitSmeltUrl(props.incident, configStore.smeltUrl));
 </script>
 
 <template>
-  <div class="submission-link">
+  <div class="submission-link d-flex align-items-center gap-2">
     <a :href="sourceUrl" target="_blank" class="rr-link">
       <i :class="sourceIcon"></i>
       {{ linkText }}
+    </a>
+    <a
+      v-if="gitSmeltUrl"
+      :href="gitSmeltUrl"
+      target="_blank"
+      class="badge bg-secondary text-decoration-none"
+      title="Link to SMELT (SLFO-Beta)"
+    >
+      SMELT
     </a>
   </div>
 </template>

--- a/assets/vue/components/SmeltLink.test.js
+++ b/assets/vue/components/SmeltLink.test.js
@@ -1,0 +1,45 @@
+import {describe, it, expect, vi} from 'vitest';
+import {mount} from '@vue/test-utils';
+import SmeltLink from './SmeltLink.vue';
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({
+    smeltUrl: 'https://smelt.example.com'
+  })
+}));
+
+describe('SmeltLink.vue', () => {
+  it('renders legacy smelt link correctly', () => {
+    const incident = {
+      type: 'smelt',
+      number: 12345,
+      packages: ['test-package']
+    };
+
+    const wrapper = mount(SmeltLink, {
+      props: {incident}
+    });
+
+    expect(wrapper.text()).toContain('12345:test-package');
+    expect(wrapper.find('a').attributes('href')).toBe('https://smelt.example.com/incident/12345');
+  });
+
+  it('renders SLFO git smelt link correctly', () => {
+    const incident = {
+      type: 'git',
+      number: 6416,
+      packages: ['test-package'],
+      url: 'https://src.suse.de/products/SLFO/pulls/6416',
+      project: 'products/SLFO'
+    };
+
+    const wrapper = mount(SmeltLink, {
+      props: {incident}
+    });
+
+    expect(wrapper.text()).toContain('SMELT');
+    expect(wrapper.find('a').attributes('href')).toBe(
+      'https://smelt.example.com/slfo-beta/updates/src.suse.de:products:SLFO:6416'
+    );
+  });
+});

--- a/assets/vue/components/SmeltLink.vue
+++ b/assets/vue/components/SmeltLink.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed} from 'vue';
 import {useConfigStore} from '@/stores/config';
+import {firstPackage, getGitSmeltUrl} from '../utils/smelt';
 
 const props = defineProps({
   incident: {type: Object, required: true}
@@ -8,13 +9,19 @@ const props = defineProps({
 
 const configStore = useConfigStore();
 
-const smeltLink = computed(() => `${configStore.smeltUrl}/incident/${props.incident.number}`);
-const packageName = computed(() => props.incident.packages[0]);
+const smeltLink = computed(
+  () =>
+    getGitSmeltUrl(props.incident, configStore.smeltUrl) ?? `${configStore.smeltUrl}/incident/${props.incident.number}`
+);
+
+const linkText = computed(() =>
+  props.incident.type === 'git' ? 'SMELT' : `${props.incident.number}:${firstPackage(props.incident)}`
+);
 </script>
 
 <template>
   <div class="submission-link">
-    <a :href="smeltLink" target="_blank">{{ incident.number }}:{{ packageName }}</a>
+    <a :href="smeltLink" target="_blank">{{ linkText }}</a>
   </div>
 </template>
 

--- a/assets/vue/utils/smelt.js
+++ b/assets/vue/utils/smelt.js
@@ -1,0 +1,12 @@
+export function firstPackage(submission) {
+  return submission?.packages?.[0] ?? '';
+}
+
+export function getGitSmeltUrl(submission, smeltUrl) {
+  if (submission?.type !== 'git' || !submission?.project || !submission?.url) return null;
+
+  const host = submission.url.match(/^(?:https?:\/\/)?([^/]+)/)?.[1];
+  return host
+    ? `${smeltUrl}/slfo-beta/updates/${host}:${submission.project.replaceAll('/', ':')}:${submission.number}`
+    : null;
+}

--- a/assets/vue/utils/smelt.test.js
+++ b/assets/vue/utils/smelt.test.js
@@ -1,0 +1,58 @@
+import {describe, it, expect} from 'vitest';
+import {firstPackage, getGitSmeltUrl} from './smelt';
+
+const smeltUrl = 'https://smelt.example.com';
+
+describe('smelt utility', () => {
+  describe('firstPackage', () => {
+    it.each([
+      ['returns first package', {packages: ['a', 'b']}, 'a'],
+      ['empty string for empty packages', {packages: []}, ''],
+      ['empty string for missing packages', {}, ''],
+      ['empty string for null submission', null, '']
+    ])('%s', (_desc, submission, expected) => {
+      expect(firstPackage(submission)).toBe(expected);
+    });
+  });
+
+  describe('getGitSmeltUrl', () => {
+    it('returns null for non-git submissions', () => {
+      const submission = {type: 'smelt', project: 'products/SLFO', url: 'https://src.suse.de/x', number: 6416};
+      expect(getGitSmeltUrl(submission, smeltUrl)).toBeNull();
+    });
+
+    it('returns null when url is empty', () => {
+      const submission = {type: 'git', project: 'products/SLFO', url: '', number: 6416};
+      expect(getGitSmeltUrl(submission, smeltUrl)).toBeNull();
+    });
+
+    it('returns null when project is missing', () => {
+      const submission = {type: 'git', url: 'https://src.suse.de/x', number: 6416};
+      expect(getGitSmeltUrl(submission, smeltUrl)).toBeNull();
+    });
+
+    it('constructs the config-driven smelt update URL for git submissions', () => {
+      const submission = {
+        type: 'git',
+        project: 'products/SLFO',
+        url: 'https://src.suse.de/products/SLFO/pulls/6416',
+        number: 6416
+      };
+      expect(getGitSmeltUrl(submission, smeltUrl)).toBe(
+        'https://smelt.example.com/slfo-beta/updates/src.suse.de:products:SLFO:6416'
+      );
+    });
+
+    it('parses the gitea host even without a protocol', () => {
+      const submission = {
+        type: 'git',
+        project: 'products/SLFO',
+        url: 'src.suse.de/products/SLFO/pulls/6416',
+        number: 6416
+      };
+      expect(getGitSmeltUrl(submission, smeltUrl)).toBe(
+        'https://smelt.example.com/slfo-beta/updates/src.suse.de:products:SLFO:6416'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Motivation:
For Gitea-based SLFO submissions, users need a direct link to the new SMELT
slfo-beta updates route to quickly access detailed priorities and metadata.

Design Choices:
Implemented a robust helper to construct the SMELT SLFO URL from git
submissions using declarative functional patterns. Updated RequestLink and
SmeltLink components to compute properties with concise ternary operations.

Benefits:
Provides seamless navigation from the dashboard to detailed Gitea SMELT pages,
improving user workflow while maintaining a clean, easily maintainable codebase.