### PR TITLE
Show accepted-for-incident job groups as orange on Blocked page

### DIFF
--- a/assets/vue/components/BlockedSubmission.vue
+++ b/assets/vue/components/BlockedSubmission.vue
@@ -36,6 +36,7 @@ const updateResultsGrouped = computed(() => {
         failed: 0,
         stopped: 0,
         waiting: 0,
+        accepted: 0,
         linkinfo: {...value.linkinfo, flavor: []}
       };
     }
@@ -46,6 +47,7 @@ const updateResultsGrouped = computed(() => {
     res.stopped += value.stopped || 0;
     res.waiting += value.waiting || 0;
     res.failed += value.failed || 0;
+    res.accepted += value.accepted || 0;
     return acc;
   }, {});
 

--- a/assets/vue/components/ResultSummary.test.js
+++ b/assets/vue/components/ResultSummary.test.js
@@ -27,6 +27,15 @@ describe('ResultSummary.vue', () => {
     expect(wrapper.text()).toContain('1/2');
   });
 
+  it('uses a distinct icon for "accepted" rather than just a different color of the "passed" icon', () => {
+    const acceptedWrapper = mount(ResultSummary, {props: {result: {name: 'Group', accepted: 1, linkinfo}}});
+    const passedWrapper = mount(ResultSummary, {props: {result: {name: 'Group', passed: 1, linkinfo}}});
+
+    expect(acceptedWrapper.find('.fa-user-check').exists()).toBe(true);
+    expect(acceptedWrapper.find('.fa-check-circle').exists()).toBe(false);
+    expect(passedWrapper.find('.fa-check-circle').exists()).toBe(true);
+  });
+
   it('keeps the box red but adds a badge when only some failures are accepted', () => {
     const wrapper = mount(ResultSummary, {
       props: {result: {name: 'Group', failed: 1, accepted: 1, passed: 1, linkinfo}}

--- a/assets/vue/components/ResultSummary.test.js
+++ b/assets/vue/components/ResultSummary.test.js
@@ -1,0 +1,45 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {mount} from '@vue/test-utils';
+import {createPinia, setActivePinia} from 'pinia';
+import ResultSummary from './ResultSummary.vue';
+
+describe('ResultSummary.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  const linkinfo = {groupid: 55, distri: 'sle', build: '20250317-1'};
+
+  it('renders a plain failed box (no accepted jobs) without an accepted badge', () => {
+    const wrapper = mount(ResultSummary, {props: {result: {name: 'Group', failed: 1, passed: 1, linkinfo}}});
+
+    expect(wrapper.find('a.btn-danger').exists()).toBe(true);
+    expect(wrapper.find('a.btn-warning').exists()).toBe(false);
+    expect(wrapper.text()).toContain('1/2');
+    expect(wrapper.text()).not.toContain('accepted');
+  });
+
+  it('renders an orange box when all failures are accepted for this incident', () => {
+    const wrapper = mount(ResultSummary, {props: {result: {name: 'Group', accepted: 1, passed: 1, linkinfo}}});
+
+    expect(wrapper.find('a.btn-danger').exists()).toBe(false);
+    expect(wrapper.find('a.btn-warning').exists()).toBe(true);
+    expect(wrapper.text()).toContain('1/2');
+  });
+
+  it('keeps the box red but adds a badge when only some failures are accepted', () => {
+    const wrapper = mount(ResultSummary, {
+      props: {result: {name: 'Group', failed: 1, accepted: 1, passed: 1, linkinfo}}
+    });
+
+    expect(wrapper.find('a.btn-danger').exists()).toBe(true);
+    expect(wrapper.text()).toContain('1/3');
+    expect(wrapper.text()).toContain('+1 accepted');
+  });
+
+  it('does not show the accepted badge on a fully accepted (non-failed) box', () => {
+    const wrapper = mount(ResultSummary, {props: {result: {name: 'Group', accepted: 2, linkinfo}}});
+
+    expect(wrapper.text()).not.toContain('+2 accepted');
+  });
+});

--- a/assets/vue/components/ResultSummary.vue
+++ b/assets/vue/components/ResultSummary.vue
@@ -15,22 +15,30 @@ const stateConfig = {
   failed: {btnClass: 'btn-danger', iconClass: 'fa-times-circle', label: 'failed jobs'},
   stopped: {btnClass: 'btn-secondary', iconClass: 'fa-stop-circle', label: 'stopped jobs'},
   waiting: {btnClass: 'btn-primary', iconClass: 'fa-clock', label: 'waiting jobs'},
+  // Jobs marked "@review:acceptable_for" this incident: not a genuine pass, but not blocking either.
+  accepted: {btnClass: 'btn-warning', iconClass: 'fa-check-circle', label: 'accepted jobs'},
   passed: {btnClass: 'btn-success', iconClass: 'fa-check-circle', label: 'passed jobs'}
 };
 
 const currentConfig = computed(() => stateConfig[state.value]);
+
+// Jobs still genuinely failing while others in the same box were accepted for this incident - the box stays
+// red (it's still blocking) but this badge makes the partial acceptance visible instead of hiding it.
+const acceptedWhileFailing = computed(() => (state.value === 'failed' ? props.result.accepted || 0 : 0));
 
 const counts = computed(() => {
   const stopped = props.result.stopped || 0;
   const passed = props.result.passed || 0;
   const waiting = props.result.waiting || 0;
   const failed = props.result.failed || 0;
-  const total = stopped + failed + waiting + passed;
+  const accepted = props.result.accepted || 0;
+  const total = stopped + failed + waiting + passed + accepted;
 
   if (state.value === 'passed') return total;
   if (state.value === 'failed') return `${failed}/${total}`;
   if (state.value === 'stopped') return `${stopped}/${total}`;
   if (state.value === 'waiting') return `${waiting}/${total}`;
+  if (state.value === 'accepted') return `${accepted}/${total}`;
   return total;
 });
 
@@ -60,6 +68,13 @@ const link = computed(() => {
     <span>
       <i class="fas me-1" :class="currentConfig.iconClass" aria-hidden="true"></i>
       {{ result.name }} <span class="badge bg-light text-dark">{{ counts }}</span>
+      <span
+        v-if="acceptedWhileFailing > 0"
+        class="badge bg-warning text-dark ms-1"
+        :title="`${acceptedWhileFailing} of the failed job(s) are marked @review:acceptable_for this incident`"
+      >
+        +{{ acceptedWhileFailing }} accepted
+      </span>
     </span>
     <small class="opacity-75 subtitle" :class="{invisible: !$slots.subtitle}">
       <slot name="subtitle">&nbsp;</slot>

--- a/assets/vue/components/ResultSummary.vue
+++ b/assets/vue/components/ResultSummary.vue
@@ -15,8 +15,9 @@ const stateConfig = {
   failed: {btnClass: 'btn-danger', iconClass: 'fa-times-circle', label: 'failed jobs'},
   stopped: {btnClass: 'btn-secondary', iconClass: 'fa-stop-circle', label: 'stopped jobs'},
   waiting: {btnClass: 'btn-primary', iconClass: 'fa-clock', label: 'waiting jobs'},
-  // Jobs marked "@review:acceptable_for" this incident: not a genuine pass, but not blocking either.
-  accepted: {btnClass: 'btn-warning', iconClass: 'fa-check-circle', label: 'accepted jobs'},
+  // Jobs marked "@review:acceptable_for" this incident: not a genuine pass, but not blocking either. Uses a
+  // distinct icon (not just fa-check-circle in a different color) so it's still distinguishable from "passed".
+  accepted: {btnClass: 'btn-warning', iconClass: 'fa-user-check', label: 'accepted jobs'},
   passed: {btnClass: 'btn-success', iconClass: 'fa-check-circle', label: 'passed jobs'}
 };
 

--- a/assets/vue/helpers/filtering.js
+++ b/assets/vue/helpers/filtering.js
@@ -1,5 +1,5 @@
-export const VISIBLE_STATES = ['failed', 'passed', 'stopped', 'waiting'];
-export const DEFAULT_STATES = ['failed', 'stopped', 'waiting'];
+export const VISIBLE_STATES = ['failed', 'accepted', 'passed', 'stopped', 'waiting'];
+export const DEFAULT_STATES = ['failed', 'accepted', 'stopped', 'waiting'];
 
 export function makeGroupNamesFilters(groupNames) {
   if (!groupNames) return [];
@@ -24,11 +24,15 @@ export function getResultState(result) {
   const passed = result.passed || 0;
   const waiting = result.waiting || 0;
   const failed = result.failed || 0;
-  const total = stopped + failed + waiting + passed;
+  const accepted = result.accepted || 0;
+  const total = stopped + failed + waiting + passed + accepted;
 
+  // "failed" wins even when some failures are accepted (still blocking) - ResultSummary shows the accepted
+  // count as a badge on top of the failed state rather than as a separate filterable state.
   if (failed > 0) return 'failed';
   if (stopped > 0) return 'stopped';
   if (waiting > 0) return 'waiting';
+  if (accepted > 0) return 'accepted';
   if (passed === total && total > 0) return 'passed';
   return 'other';
 }

--- a/assets/vue/helpers/filtering.test.js
+++ b/assets/vue/helpers/filtering.test.js
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest';
-import {makeGroupNamesFilters, checkResult, checkResults} from './filtering';
+import {makeGroupNamesFilters, checkResult, checkResults, getResultState, checkState, hasAnyState} from './filtering';
 
 describe('filtering helper', () => {
   describe('makeGroupNamesFilters', () => {
@@ -45,6 +45,49 @@ describe('filtering helper', () => {
         res2: {name: 'baz'}
       };
       expect(checkResults(results, filters)).toBe(false);
+    });
+  });
+
+  describe('getResultState', () => {
+    it('returns "failed" when there are genuine failures', () => {
+      expect(getResultState({failed: 1, passed: 2})).toBe('failed');
+    });
+
+    it('returns "failed" even when some jobs are also accepted (partial acceptance stays blocking)', () => {
+      expect(getResultState({failed: 1, accepted: 1, passed: 1})).toBe('failed');
+    });
+
+    it('returns "stopped" over "waiting"/"accepted" when there is no genuine failure', () => {
+      expect(getResultState({stopped: 1, waiting: 1, accepted: 1, passed: 1})).toBe('stopped');
+    });
+
+    it('returns "waiting" over "accepted" when there is no genuine failure or stopped job', () => {
+      expect(getResultState({waiting: 1, accepted: 1, passed: 1})).toBe('waiting');
+    });
+
+    it('returns "accepted" when all failures for this incident are covered by acceptable_for remarks', () => {
+      expect(getResultState({accepted: 1, passed: 1})).toBe('accepted');
+    });
+
+    it('returns "passed" when every job genuinely passed', () => {
+      expect(getResultState({passed: 3})).toBe('passed');
+    });
+
+    it('returns "other" for an empty result', () => {
+      expect(getResultState({})).toBe('other');
+    });
+  });
+
+  describe('checkState / hasAnyState', () => {
+    it('checkState matches the computed state against the selected states', () => {
+      expect(checkState({accepted: 1, passed: 1}, ['accepted'])).toBe(true);
+      expect(checkState({accepted: 1, passed: 1}, ['failed'])).toBe(false);
+    });
+
+    it('hasAnyState returns true if any result matches the selected states', () => {
+      const results = {res1: {passed: 1}, res2: {accepted: 1, passed: 1}};
+      expect(hasAnyState(results, ['accepted'])).toBe(true);
+      expect(hasAnyState(results, ['failed'])).toBe(false);
     });
   });
 });

--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,7 @@ requires 'Devel::Cover';
 requires 'JSON::Validator';
 requires 'YAML::XS';
 requires 'IO::Socket::SSL', '>= 2.009';
-requires 'MCP';
+requires 'MCP', '< 0.15';
 
 on 'test' => sub {
     requires 'CPAN::Audit';

--- a/lib/Dashboard/Model/Incidents.pm
+++ b/lib/Dashboard/Model/Incidents.pm
@@ -6,6 +6,17 @@ use Mojo::Base -base, -signatures;
 
 has [qw(log pg)];
 
+# Jobs remarked "acceptable_for" a given incident are reported as this synthetic status instead of their real
+# openqa_jobs.status so /blocked can render them distinctly (orange) rather than as a genuine pass or failure.
+# The ELSE branch is cast to text because openqa_jobs.status is the qa_status enum, which has no 'accepted' member.
+use constant _ACCEPTABLE_FOR_STATUS_CASE_SQL => q{
+  CASE
+      WHEN (SELECT COUNT(jr.id) FROM job_remarks jr WHERE jr.openqa_job_id = oj.id AND jr.incident_id = ? AND jr.text = 'acceptable_for' LIMIT 1) > 0
+      THEN 'accepted'
+      ELSE oj.status::text
+  END AS incident_status
+};
+
 sub blocked ($self) {
   my $incidents = $self->pg->db->query(
     "SELECT * FROM incidents
@@ -197,11 +208,7 @@ sub _incident_openqa_jobs ($self, $inc) {
     "WITH openqa_status_for_incident AS (
      SELECT
          oj.id AS openqa_job_id,
-         CASE
-             WHEN (SELECT COUNT(jr.id) FROM job_remarks jr WHERE jr.openqa_job_id = oj.id AND jr.incident_id = ? AND jr.text = 'acceptable_for' LIMIT 1) > 0
-             THEN 'passed'
-             ELSE oj.status
-         END AS incident_status
+         " . _ACCEPTABLE_FOR_STATUS_CASE_SQL . "
      FROM openqa_jobs oj
      )
      SELECT
@@ -251,11 +258,7 @@ sub _update_openqa_jobs ($self, $inc) {
     "WITH openqa_status_for_incident AS (
      SELECT
          oj.id AS openqa_job_id,
-         CASE
-             WHEN (SELECT COUNT(jr.id) FROM job_remarks jr WHERE jr.openqa_job_id = oj.id AND jr.incident_id = ? AND jr.text = 'acceptable_for' LIMIT 1) > 0
-             THEN 'passed'
-             ELSE oj.status
-         END AS incident_status
+         " . _ACCEPTABLE_FOR_STATUS_CASE_SQL . "
      FROM openqa_jobs oj
      )
      SELECT

--- a/t/json.t
+++ b/t/json.t
@@ -201,7 +201,8 @@ subtest 'Blocked by Tests' => sub {
               "55" => {
                 "name"     => 'Server-DVD-Incidents 12-SP6',
                 "linkinfo" => {"build" => "20250317-1", "distri" => "sle", "groupid" => 55},
-                "passed"   => 2
+                "passed"   => 1,
+                "accepted" => 1
               },
               "282" => {
                 "linkinfo" => {"build" => ":16860:perl-Mojolicious", "distri" => "sle", "groupid" => 282},
@@ -239,8 +240,9 @@ subtest 'Blocked by Tests' => sub {
                   "groupid" => 55,
                   "version" => "12-SP6"
                 },
-                "name"   => "Server-DVD-Incidents 12-SP6",
-                "passed" => 2
+                "name"     => "Server-DVD-Incidents 12-SP6",
+                "passed"   => 1,
+                "accepted" => 1
               }
             }
           },

--- a/t/models.t
+++ b/t/models.t
@@ -213,6 +213,27 @@ subtest 'Dashboard::Model::Incidents' => sub {
     ok $incs->_incident_openqa_jobs($inc), 'works with multiple jobs in same group';
   };
 
+  subtest 'acceptable_for remarks are reported as "accepted", not "passed"' => sub {
+    my $incs = $t->app->incidents;
+
+    # Fixture: group 55 has one job failed+remarked "acceptable_for" for 16860 and one job genuinely passed
+    my $inc_16860     = $incs->incident_for_number(16860);
+    my $res_16860     = $incs->_incident_openqa_jobs($inc_16860);
+    my $upd_res_16860 = $incs->_update_openqa_jobs($inc_16860);
+    is $res_16860->{55}{accepted}, 1,     'remarked job counts as accepted for incident 16860';
+    is $res_16860->{55}{passed},   1,     'genuinely passing job still counts as passed';
+    is $res_16860->{55}{failed},   undef, 'remarked job is no longer counted as failed';
+    is $upd_res_16860->{'55 Server-DVD-Incidents 12-SP6'}{accepted}, 1,
+      'update jobs see the same remarked job as accepted';
+
+    # The remark is scoped to 16860 only, so 29722 (sharing the same job) must still see the genuine failure
+    my $inc_29722 = $incs->incident_for_number(29722);
+    my $res_29722 = $incs->_update_openqa_jobs($inc_29722);
+    is $res_29722->{'55 Server-DVD-Incidents 12-SP6'}{failed}, 1, 'incident 29722 still sees the real failure';
+    is $res_29722->{'55 Server-DVD-Incidents 12-SP6'}{accepted}, undef,
+      'incident 29722 has no remark so nothing is accepted';
+  };
+
   subtest 'repos extra branch coverage' => sub {
     my $incs     = $t->app->incidents;
     my $settings = $t->app->settings;

--- a/t/ui.t.js
+++ b/t/ui.t.js
@@ -154,6 +154,7 @@ t.test('Test dashboard ui', {skip, timeout: 60000}, async t => {
     t.equal(await list.count(), 3, 'All submissions are visible by default');
 
     t.ok(await page.getByLabel('failed').isChecked());
+    t.ok(await page.getByLabel('accepted').isChecked());
     t.ok(await page.getByLabel('stopped').isChecked());
     t.ok(await page.getByLabel('waiting').isChecked());
     t.notOk(await page.getByLabel('passed').isChecked());
@@ -164,10 +165,10 @@ t.test('Test dashboard ui', {skip, timeout: 60000}, async t => {
     await page.getByLabel('failed').uncheck();
     t.notOk(await page.isVisible('text=SAP/HA Maintenance 1/5'));
     t.notOk(await page.isVisible('text=SLE 12 SP5 1/1'));
-    t.match(await page.url(), /states=stopped%2Cwaiting/);
+    t.match(await page.url(), /states=accepted%2Cstopped%2Cwaiting/);
 
     await page.getByLabel('passed').check();
-    t.match(await page.url(), /states=stopped%2Cwaiting%2Cpassed/);
+    t.match(await page.url(), /states=accepted%2Cstopped%2Cwaiting%2Cpassed/);
 
     await page.getByLabel('failed').check();
     await page.getByLabel('passed').uncheck();


### PR DESCRIPTION
Job groups on `/blocked` where every failing job is covered by an `@review:acceptable_for` openQA comment now render orange instead of green/red, so reviewers can tell "accepted" from "genuinely passed" or "still blocking" at a glance; a group with a mix of real and accepted failures stays red with a small "+N accepted" badge.

## Commits

- 6e94d54 feat: Report acceptable_for jobs as accepted, not passed
- 0fe6094 feat: Render accepted-for-incident job groups as orange on Blocked page
- 28948cd fix: Pin MCP dependency below 0.15
- 3da8e95 fix: Use a distinct icon for the accepted state

The `fix` commits (28948cd, 3da8e95) are unrelated to the feature itself: one restores green CI after an unpinned dependency's breaking release, the other addresses review feedback.
